### PR TITLE
Add Quick Look previews and Finder-style views to file manager

### DIFF
--- a/frontend/src/components/QuickLook.jsx
+++ b/frontend/src/components/QuickLook.jsx
@@ -1,0 +1,132 @@
+import { useEffect } from 'react';
+
+const QuickLook = ({
+  isOpen,
+  item,
+  previewUrl,
+  mimeType,
+  textContent,
+  loading,
+  error,
+  onClose,
+  onDownload,
+  onOpenInNewTab,
+}) => {
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const title = item?.name || 'Preview';
+  const normalizedMime = mimeType || (item?.type === 'file' ? 'application/octet-stream' : '');
+
+  const handleBackdropClick = (event) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  let content = (
+    <div className="quicklook-status">No preview available.</div>
+  );
+
+  if (loading) {
+    content = <div className="quicklook-status">Preparing preview…</div>;
+  } else if (error) {
+    content = <div className="quicklook-status error">{error}</div>;
+  } else if (textContent) {
+    content = (
+      <pre className="quicklook-text" aria-label={`Preview of ${title}`}>
+        {textContent}
+      </pre>
+    );
+  } else if (previewUrl) {
+    if (mimeType?.startsWith('image/')) {
+      content = <img className="quicklook-image" src={previewUrl} alt={title} />;
+    } else if (mimeType?.startsWith('audio/')) {
+      content = <audio className="quicklook-audio" controls src={previewUrl} aria-label={title} />;
+    } else if (mimeType?.startsWith('video/')) {
+      content = <video className="quicklook-video" controls src={previewUrl} aria-label={title} />;
+    } else if (mimeType === 'application/pdf') {
+      content = (
+        <iframe
+          title={`Preview of ${title}`}
+          src={previewUrl}
+          className="quicklook-frame"
+        />
+      );
+    } else {
+      content = (
+        <div className="quicklook-frame-wrapper">
+          <iframe
+            title={`Preview of ${title}`}
+            src={previewUrl}
+            className="quicklook-frame"
+          />
+          <p className="quicklook-hint">
+            If the preview does not render, use “Open in new tab” or download the file.
+          </p>
+        </div>
+      );
+    }
+  }
+
+  return (
+    <div
+      className="quicklook-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Quick look for ${title}`}
+      onClick={handleBackdropClick}
+    >
+      <div className="quicklook-container">
+        <header className="quicklook-header">
+          <div className="quicklook-title-group">
+            <div className="quicklook-title">{title}</div>
+            {normalizedMime && !loading && !error && (
+              <div className="quicklook-subtitle">{normalizedMime}</div>
+            )}
+          </div>
+          <button type="button" className="quicklook-close" onClick={onClose} aria-label="Close quick look">
+            ×
+          </button>
+        </header>
+        <div className="quicklook-body">{content}</div>
+        <footer className="quicklook-footer">
+          <button
+            type="button"
+            className="button secondary"
+            onClick={onDownload}
+            disabled={!onDownload}
+          >
+            Download
+          </button>
+          <button
+            type="button"
+            className="button secondary"
+            onClick={onOpenInNewTab}
+            disabled={!previewUrl}
+          >
+            Open in new tab
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default QuickLook;

--- a/frontend/src/components/Toolbar.jsx
+++ b/frontend/src/components/Toolbar.jsx
@@ -7,6 +7,10 @@ const Toolbar = ({
   onRefresh,
   onNavigateUp,
   canNavigateUp,
+  onQuickLook,
+  canQuickLook,
+  viewMode,
+  onViewModeChange,
 }) => {
   const inputRef = useRef(null);
 
@@ -36,6 +40,32 @@ const Toolbar = ({
         <span className="toolbar-path">{currentPath || 'Home'}</span>
       </div>
       <div className="toolbar-actions">
+        <div className="view-toggle" role="group" aria-label="Change view">
+          <button
+            type="button"
+            className={`view-button${viewMode === 'grid' ? ' active' : ''}`}
+            onClick={() => onViewModeChange('grid')}
+            aria-label="Icon view"
+          >
+            🗂️
+          </button>
+          <button
+            type="button"
+            className={`view-button${viewMode === 'list' ? ' active' : ''}`}
+            onClick={() => onViewModeChange('list')}
+            aria-label="List view"
+          >
+            📄
+          </button>
+        </div>
+        <button
+          type="button"
+          className="button secondary"
+          onClick={onQuickLook}
+          disabled={!canQuickLook}
+        >
+          👁️ Quick Look
+        </button>
         <button type="button" className="button" onClick={onCreateFolder}>
           📁 New Folder
         </button>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -70,7 +70,39 @@ body {
 .toolbar-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.view-toggle {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(37, 99, 235, 0.1);
+  padding: 0.2rem;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+}
+
+.view-button {
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  cursor: pointer;
+  color: #2563eb;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.view-button:hover {
+  background: rgba(37, 99, 235, 0.2);
+}
+
+.view-button.active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 10px 24px -20px rgba(37, 99, 235, 0.8);
 }
 
 .button {
@@ -93,6 +125,17 @@ body {
 .button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button.secondary {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  box-shadow: none;
+}
+
+.button.secondary:hover:not(:disabled) {
+  background: rgba(37, 99, 235, 0.2);
   box-shadow: none;
 }
 
@@ -163,6 +206,24 @@ body {
   background: rgba(37, 99, 235, 0.06);
 }
 
+.file-table tbody tr {
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.file-table tbody tr.selected {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.file-table tbody tr.selected .file-name span:last-child {
+  color: #1d4ed8;
+}
+
+.file-table tbody tr:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.6);
+  outline-offset: 2px;
+}
+
 .file-name {
   display: flex;
   align-items: center;
@@ -183,6 +244,109 @@ body {
 
 .actions-header {
   text-align: right;
+}
+
+.file-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1.1rem;
+  background: #ffffff;
+  padding: 1.25rem;
+  border-radius: 20px;
+  box-shadow: 0 30px 55px -45px rgba(15, 23, 42, 0.45);
+}
+
+.file-grid-item {
+  background: linear-gradient(180deg, #f8fafc 0%, #ffffff 70%);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 1.1rem 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  position: relative;
+  min-height: 220px;
+}
+
+.file-grid-item:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 45px -35px rgba(15, 23, 42, 0.5);
+}
+
+.file-grid-item.selected {
+  border-color: #2563eb;
+  box-shadow: 0 25px 50px -30px rgba(37, 99, 235, 0.5);
+}
+
+.file-grid-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+}
+
+.file-grid-name {
+  font-weight: 700;
+  color: #1f2937;
+  font-size: 0.95rem;
+  word-break: break-word;
+}
+
+.file-grid-meta {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.file-grid-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+  margin-top: auto;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.file-grid-item:hover .file-grid-actions,
+.file-grid-item.selected .file-grid-actions {
+  opacity: 1;
+}
+
+.pill-button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.75rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.pill-button:hover {
+  background: rgba(37, 99, 235, 0.25);
+  transform: translateY(-1px);
+}
+
+.pill-button.subtle {
+  background: rgba(107, 114, 128, 0.15);
+  color: #374151;
+}
+
+.pill-button.subtle:hover {
+  background: rgba(107, 114, 128, 0.25);
+}
+
+.pill-button.danger {
+  color: #b91c1c;
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.pill-button.danger:hover {
+  background: rgba(248, 113, 113, 0.3);
 }
 
 .empty-state {
@@ -220,6 +384,146 @@ body {
   color: #2563eb;
 }
 
+.quicklook-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(14px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.quicklook-container {
+  background: #ffffff;
+  border-radius: 22px;
+  width: min(900px, 90vw);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 40px 90px -50px rgba(15, 23, 42, 0.65);
+}
+
+.quicklook-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 1.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.quicklook-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.quicklook-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.quicklook-subtitle {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.quicklook-close {
+  border: none;
+  background: none;
+  font-size: 1.8rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #94a3b8;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.quicklook-close:hover {
+  color: #1f2937;
+  transform: scale(1.05);
+}
+
+.quicklook-body {
+  flex: 1;
+  padding: 1.5rem;
+  overflow: auto;
+  background: linear-gradient(180deg, #f8fafc 0%, #ffffff 45%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.quicklook-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.quicklook-frame {
+  width: 100%;
+  min-height: 420px;
+  border: none;
+  border-radius: 14px;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+  background: #ffffff;
+}
+
+.quicklook-frame-wrapper {
+  width: 100%;
+}
+
+.quicklook-text {
+  width: 100%;
+  max-height: 60vh;
+  overflow: auto;
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 0.85rem;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.quicklook-image {
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: 16px;
+  box-shadow: 0 35px 65px -50px rgba(15, 23, 42, 0.7);
+}
+
+.quicklook-audio,
+.quicklook-video {
+  width: 100%;
+}
+
+.quicklook-video {
+  max-height: 60vh;
+  border-radius: 16px;
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.6);
+}
+
+.quicklook-status {
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.quicklook-status.error {
+  color: #b91c1c;
+}
+
+.quicklook-hint {
+  margin-top: 0.75rem;
+  color: #64748b;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
 @media (max-width: 768px) {
   .app-container {
     padding: 1.5rem 1rem 2.5rem;
@@ -233,6 +537,21 @@ body {
   .toolbar-actions {
     width: 100%;
     justify-content: space-between;
+  }
+
+  .view-toggle {
+    width: 100%;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  .file-grid {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    padding: 1rem;
+  }
+
+  .file-grid-item {
+    min-height: 200px;
   }
 
   .file-table,
@@ -271,5 +590,13 @@ body {
 
   .actions-header {
     display: none;
+  }
+
+  .quicklook-container {
+    width: 95vw;
+  }
+
+  .quicklook-body {
+    padding: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- add MIME detection and a streaming endpoint so files can be previewed or downloaded directly from the NAS API while including stable item paths in listings
- redesign the React UI with Finder-like icon/list toggle, item selection, Quick Look modal previews, and inline download controls
- introduce a shared file-content fetch helper plus styling updates for the new Quick Look overlay and icon grid experience

## Testing
- npm install *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ca4b523bc8832d9493a66e8236a4dc