### PR TITLE
Implement authentication and role-based dashboards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,462 +1,125 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import Breadcrumbs from './components/Breadcrumbs.jsx';
-import FileList from './components/FileList.jsx';
-import QuickLook from './components/QuickLook.jsx';
-import Toolbar from './components/Toolbar.jsx';
+import { useCallback, useEffect, useState } from 'react';
+import AdminDashboard from './components/AdminDashboard.jsx';
+import UserDashboard from './components/UserDashboard.jsx';
+import LoginForm from './components/LoginForm.jsx';
 import {
-  listItems,
-  createFolder,
-  uploadFiles,
-  deleteItem,
-  renameItem,
-  lockItem,
-  unlockItem,
-  fetchFileContent,
+  setAuthToken,
+  login as apiLogin,
+  logout as apiLogout,
+  getCurrentUser,
+  changeMyPassword,
 } from './services/api.js';
 
-const joinPath = (base, name) => (base ? `${base}/${name}` : name);
-
-const initialQuickLookState = {
-  open: false,
-  loading: false,
-  error: '',
-  url: '',
-  mimeType: '',
-  textContent: '',
-  item: null,
-};
+const AUTH_TOKEN_KEY = 'hts-auth-token';
 
 const App = () => {
-  const [currentPath, setCurrentPath] = useState('');
-  const [items, setItems] = useState([]);
-  const [breadcrumbs, setBreadcrumbs] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [message, setMessage] = useState('');
-  const [refreshToken, setRefreshToken] = useState(0);
-  const [viewMode, setViewMode] = useState(() => {
-    if (typeof window !== 'undefined') {
-      return window.localStorage.getItem('hts-view-mode') || 'grid';
-    }
-    return 'grid';
-  });
-  const [selectedItem, setSelectedItem] = useState(null);
-  const [quickLook, setQuickLook] = useState(initialQuickLookState);
-  const previewUrlRef = useRef('');
+  const [authState, setAuthState] = useState({ status: 'loading', user: null, token: '' });
+  const [authError, setAuthError] = useState('');
 
   useEffect(() => {
-    let active = true;
-    setLoading(true);
-    setError('');
-
-    listItems(currentPath)
+    const token = typeof window !== 'undefined' ? window.localStorage.getItem(AUTH_TOKEN_KEY) : '';
+    if (!token) {
+      setAuthState({ status: 'guest', user: null, token: '' });
+      return;
+    }
+    setAuthToken(token);
+    getCurrentUser()
       .then((data) => {
-        if (!active) {
-          return;
-        }
-        const nextItems = data.items || [];
-        setItems(nextItems);
-        setBreadcrumbs(data.breadcrumbs || []);
-        const normalizedPath = data.path || '';
-        if (normalizedPath !== currentPath) {
-          setCurrentPath(normalizedPath);
-        }
+        setAuthState({ status: 'authenticated', user: data.user, token });
       })
-      .catch((err) => {
-        if (!active) {
-          return;
+      .catch(() => {
+        setAuthToken('');
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem(AUTH_TOKEN_KEY);
         }
-        setError(err.message || 'Failed to load items');
-      })
-      .finally(() => {
-        if (active) {
-          setLoading(false);
-        }
+        setAuthState({ status: 'guest', user: null, token: '' });
       });
-
-    return () => {
-      active = false;
-    };
-  }, [currentPath, refreshToken]);
-
-  useEffect(() => {
-    if (!message) {
-      return undefined;
-    }
-    const timeout = setTimeout(() => setMessage(''), 4000);
-    return () => clearTimeout(timeout);
-  }, [message]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('hts-view-mode', viewMode);
-    }
-  }, [viewMode]);
-
-  useEffect(() => {
-    setSelectedItem(null);
-  }, [currentPath]);
-
-  useEffect(() => {
-    setSelectedItem((current) => {
-      if (!current) {
-        return current;
-      }
-      return items.find((item) => item.path === current.path) || null;
-    });
-  }, [items]);
-
-  useEffect(() => () => {
-    if (previewUrlRef.current) {
-      URL.revokeObjectURL(previewUrlRef.current);
-    }
   }, []);
 
-  useEffect(() => {
-    if (!quickLook.open || !quickLook.item) {
-      return;
-    }
-    const exists = items.some((item) => item.path === quickLook.item.path);
-    if (!exists) {
-      if (previewUrlRef.current) {
-        URL.revokeObjectURL(previewUrlRef.current);
-        previewUrlRef.current = '';
-      }
-      setQuickLook(initialQuickLookState);
-    }
-  }, [items, quickLook.open, quickLook.item]);
-
-  const refresh = () => {
-    setRefreshToken((token) => token + 1);
-  };
-
-  const handleNavigate = (path) => {
-    setCurrentPath(path || '');
-  };
-
-  const parentPath = useMemo(() => {
-    if (!currentPath) {
-      return '';
-    }
-    const segments = currentPath.split('/');
-    segments.pop();
-    return segments.join('/');
-  }, [currentPath]);
-
-  const handleNavigateUp = () => {
-    if (!currentPath) {
-      return;
-    }
-    handleNavigate(parentPath);
-  };
-
-  const performAction = async (action, successMessage) => {
+  const handleLogout = useCallback(async () => {
     try {
-      setError('');
-      setMessage('');
-      await action();
-      if (successMessage) {
-        setMessage(successMessage);
+      if (authState.status === 'authenticated') {
+        await apiLogout();
       }
-      refresh();
     } catch (err) {
-      setError(err.message || 'Something went wrong');
-    }
-  };
-
-  const handleCreateFolder = async () => {
-    const name = window.prompt('Folder name');
-    if (!name) {
-      return;
-    }
-    const trimmed = name.trim();
-    if (!trimmed) {
-      setError('Folder name cannot be empty');
-      return;
-    }
-    await performAction(
-      () => createFolder(currentPath, trimmed),
-      `Folder “${trimmed}” created`
-    );
-  };
-
-  const handleUpload = async (files) => {
-    if (!files || files.length === 0) {
-      return;
-    }
-    await performAction(
-      () => uploadFiles(currentPath, files),
-      files.length === 1
-        ? `Uploaded “${files[0].name}”`
-        : `Uploaded ${files.length} files`
-    );
-  };
-
-  const handleOpen = (item) => {
-    if (item.type === 'directory') {
-      handleNavigate(item.path || joinPath(currentPath, item.name));
-    }
-  };
-
-  const handleDelete = async (item) => {
-    const confirmed = window.confirm(`Delete ${item.type === 'directory' ? 'folder' : 'file'} “${item.name}”?`);
-    if (!confirmed) {
-      return;
-    }
-    let password;
-    if (item.isLocked) {
-      password = window.prompt('Enter the password to delete this locked item');
-      if (!password) {
-        setMessage('Deletion cancelled');
-        return;
+      // ignore logout errors
+    } finally {
+      setAuthToken('');
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem(AUTH_TOKEN_KEY);
       }
+      setAuthState({ status: 'guest', user: null, token: '' });
     }
+  }, [authState.status]);
 
-    await performAction(
-      () => deleteItem(item.path || joinPath(currentPath, item.name), password || undefined),
-      `Deleted “${item.name}”`
-    );
-  };
-
-  const handleRename = async (item) => {
-    const newName = window.prompt('Enter the new name', item.name);
-    if (!newName) {
+  const refreshUser = useCallback(async () => {
+    if (!authState.token) {
       return;
     }
-    const trimmed = newName.trim();
-    if (!trimmed) {
-      setError('New name cannot be empty');
-      return;
-    }
-    if (trimmed === item.name) {
-      return;
-    }
-
-    let password;
-    if (item.isLocked) {
-      password = window.prompt('Enter the password to rename this locked item');
-      if (!password) {
-        setMessage('Rename cancelled');
-        return;
-      }
-    }
-
-    await performAction(
-      () => renameItem(item.path || joinPath(currentPath, item.name), trimmed, password || undefined),
-      `Renamed to “${trimmed}”`
-    );
-  };
-
-  const handleToggleLock = async (item) => {
-    if (item.isLocked) {
-      const password = window.prompt('Enter the password to unlock this item');
-      if (!password) {
-        setMessage('Unlock cancelled');
-        return;
-      }
-      await performAction(
-        () => unlockItem(item.path || joinPath(currentPath, item.name), password),
-        `Unlocked “${item.name}”`
-      );
-      return;
-    }
-
-    const password = window.prompt('Set a password to lock this item');
-    if (!password) {
-      setMessage('Lock cancelled');
-      return;
-    }
-    await performAction(
-      () => lockItem(item.path || joinPath(currentPath, item.name), password),
-      `Locked “${item.name}”`
-    );
-  };
-
-  const handleSelectItem = (item) => {
-    setSelectedItem(item);
-  };
-
-  const closeQuickLook = () => {
-    if (previewUrlRef.current) {
-      URL.revokeObjectURL(previewUrlRef.current);
-      previewUrlRef.current = '';
-    }
-    setQuickLook(initialQuickLookState);
-  };
-
-  const handleQuickLook = async (targetItem) => {
-    const item = targetItem || selectedItem;
-    if (!item || item.type !== 'file') {
-      return;
-    }
-
-    let password;
-    if (item.isLocked) {
-      const input = window.prompt('Enter the password to preview this locked file');
-      if (!input) {
-        setMessage('Preview cancelled');
-        return;
-      }
-      password = input;
-    }
-
-    setError('');
-    if (previewUrlRef.current) {
-      URL.revokeObjectURL(previewUrlRef.current);
-      previewUrlRef.current = '';
-    }
-
-    setQuickLook({
-      open: true,
-      loading: true,
-      error: '',
-      url: '',
-      mimeType: '',
-      textContent: '',
-      item,
-    });
-
     try {
-      const { blob, contentType } = await fetchFileContent(item.path || joinPath(currentPath, item.name), {
-        password,
-      });
-      let textContent = '';
-      if (contentType.startsWith('text/') || contentType === 'application/json') {
-        textContent = await blob.text();
-      }
-      const objectUrl = URL.createObjectURL(blob);
-      previewUrlRef.current = objectUrl;
-      setQuickLook({
-        open: true,
-        loading: false,
-        error: '',
-        url: objectUrl,
-        mimeType: contentType,
-        textContent,
-        item,
-      });
+      const data = await getCurrentUser();
+      setAuthState((prev) => ({ status: 'authenticated', user: data.user, token: prev.token }));
     } catch (err) {
-      setQuickLook({
-        open: true,
-        loading: false,
-        error: err.message || 'Unable to preview file',
-        url: '',
-        mimeType: '',
-        textContent: '',
-        item,
-      });
+      handleLogout();
     }
-  };
+  }, [authState.token, handleLogout]);
 
-  const handleDownload = async (item) => {
-    if (!item || item.type !== 'file') {
-      return;
-    }
-
-    let password;
-    if (item.isLocked) {
-      const input = window.prompt('Enter the password to download this locked file');
-      if (!input) {
-        setMessage('Download cancelled');
-        return;
-      }
-      password = input;
-    }
-
+  const handleLogin = async ({ username, password }) => {
     try {
-      setError('');
-      const { blob, filename } = await fetchFileContent(item.path || joinPath(currentPath, item.name), {
-        password,
-        download: true,
-      });
-      const downloadUrl = URL.createObjectURL(blob);
-      const anchor = document.createElement('a');
-      anchor.href = downloadUrl;
-      anchor.download = filename || item.name;
-      document.body.appendChild(anchor);
-      anchor.click();
-      document.body.removeChild(anchor);
-      URL.revokeObjectURL(downloadUrl);
-      setMessage(`Download started for “${filename || item.name}”`);
+      setAuthError('');
+      const { token, user } = await apiLogin(username, password);
+      setAuthToken(token);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(AUTH_TOKEN_KEY, token);
+      }
+      setAuthState({ status: 'authenticated', user, token });
     } catch (err) {
-      setError(err.message || 'Unable to download file');
+      setAuthError(err.message || 'Unable to sign in');
     }
   };
 
-  const handleOpenPreviewInNewTab = () => {
-    if (!quickLook.url) {
-      return;
-    }
-    const opened = window.open(quickLook.url, '_blank', 'noopener');
-    if (!opened) {
-      setError('Unable to open the preview in a new tab. Please allow pop-ups for this site.');
-    }
+  const handlePasswordChange = async ({ currentPassword, newPassword }) => {
+    await changeMyPassword(currentPassword, newPassword);
+    await refreshUser();
   };
 
-  const canQuickLook = selectedItem?.type === 'file';
-  const quickLookDownloadHandler = quickLook.item ? () => handleDownload(quickLook.item) : undefined;
+  if (authState.status === 'loading') {
+    return (
+      <div className="app-container centered">
+        <div className="loading">Loading…</div>
+      </div>
+    );
+  }
+
+  if (authState.status !== 'authenticated' || !authState.user) {
+    return (
+      <div className="app-container centered auth-layout">
+        <LoginForm onSubmit={handleLogin} error={authError} />
+      </div>
+    );
+  }
+
+  const { user } = authState;
+  if (user.role === 'admin') {
+    return (
+      <div className="app-container dashboard-container">
+        <AdminDashboard
+          user={user}
+          onLogout={handleLogout}
+          onPasswordChange={handlePasswordChange}
+          onRefreshUser={refreshUser}
+        />
+      </div>
+    );
+  }
 
   return (
-    <div className="app-container">
-      <header className="app-header">
-        <h1>HTS NAS</h1>
-        <p className="subtitle">Browse, organize, and secure your shared storage.</p>
-      </header>
-
-      <Toolbar
-        currentPath={currentPath}
-        onCreateFolder={handleCreateFolder}
-        onUpload={handleUpload}
-        onRefresh={refresh}
-        onNavigateUp={handleNavigateUp}
-        canNavigateUp={Boolean(currentPath)}
-        onQuickLook={() => handleQuickLook()}
-        canQuickLook={canQuickLook}
-        viewMode={viewMode}
-        onViewModeChange={setViewMode}
-      />
-
-      <Breadcrumbs breadcrumbs={breadcrumbs} onNavigate={handleNavigate} />
-
-      {error && (
-        <div className="alert error" role="alert">
-          {error}
-        </div>
-      )}
-      {message && (
-        <div className="alert success" role="status">
-          {message}
-        </div>
-      )}
-
-      {loading ? (
-        <div className="loading">Loading…</div>
-      ) : (
-        <FileList
-          items={items}
-          viewMode={viewMode}
-          selectedItem={selectedItem}
-          onSelect={handleSelectItem}
-          onOpen={handleOpen}
-          onQuickLook={handleQuickLook}
-          onRename={handleRename}
-          onDelete={handleDelete}
-          onToggleLock={handleToggleLock}
-          onDownload={handleDownload}
-        />
-      )}
-
-      <QuickLook
-        isOpen={quickLook.open}
-        item={quickLook.item}
-        previewUrl={quickLook.url}
-        mimeType={quickLook.mimeType}
-        textContent={quickLook.textContent}
-        loading={quickLook.loading}
-        error={quickLook.error}
-        onClose={closeQuickLook}
-        onDownload={quickLookDownloadHandler}
-        onOpenInNewTab={handleOpenPreviewInNewTab}
+    <div className="app-container dashboard-container">
+      <UserDashboard
+        user={user}
+        onLogout={handleLogout}
+        onPasswordChange={handlePasswordChange}
+        onRefreshUser={refreshUser}
       />
     </div>
   );

--- a/frontend/src/components/AccessList.jsx
+++ b/frontend/src/components/AccessList.jsx
@@ -1,0 +1,40 @@
+const AccessList = ({ access = [], selectedPath, onSelect }) => {
+  if (!Array.isArray(access) || access.length === 0) {
+    return (
+      <div className="panel">
+        <div className="panel-header">
+          <h2>Assigned folders</h2>
+          <p>No folders have been assigned to this account yet.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <div className="panel-header">
+        <h2>Assigned folders</h2>
+        <p>Select a folder to browse files and see the associated password.</p>
+      </div>
+      <ul className="access-list">
+        {access.map((entry) => {
+          const isActive = selectedPath === entry.path;
+          return (
+            <li key={entry.path || '(root)'} className={isActive ? 'selected' : ''}>
+              <button
+                type="button"
+                className="access-item"
+                onClick={() => onSelect?.(entry.path)}
+              >
+                <span className="access-path">{entry.path || 'Full storage access'}</span>
+                <span className="access-password">Password: {entry.password}</span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default AccessList;

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,0 +1,34 @@
+import FileManager from './FileManager.jsx';
+import UserManagementPanel from './UserManagementPanel.jsx';
+import ChangePasswordForm from './ChangePasswordForm.jsx';
+
+const AdminDashboard = ({ user, onLogout, onPasswordChange, onRefreshUser }) => (
+  <div className="dashboard">
+    <header className="dashboard-header">
+      <div>
+        <h1>Welcome, {user.username}</h1>
+        <p className="muted">You have administrator access to the HTS NAS.</p>
+      </div>
+      <button type="button" className="button danger" onClick={onLogout}>
+        Sign out
+      </button>
+    </header>
+
+    <section className="dashboard-section">
+      <FileManager
+        title="NAS file explorer"
+        subtitle="Manage all files and folders stored on the NAS."
+      />
+    </section>
+
+    <section className="dashboard-section">
+      <UserManagementPanel onUsersChanged={onRefreshUser} />
+    </section>
+
+    <section className="dashboard-section">
+      <ChangePasswordForm title="Update your administrator password" onSubmit={onPasswordChange} />
+    </section>
+  </div>
+);
+
+export default AdminDashboard;

--- a/frontend/src/components/ChangePasswordForm.jsx
+++ b/frontend/src/components/ChangePasswordForm.jsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+
+const ChangePasswordForm = ({ title = 'Change Password', onSubmit }) => {
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [status, setStatus] = useState({ error: '', success: '' });
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ error: '', success: '' });
+    if (!currentPassword || !newPassword) {
+      setStatus({ error: 'Please provide your current and new password.', success: '' });
+      return;
+    }
+    if (newPassword.length < 4) {
+      setStatus({ error: 'New password must be at least 4 characters long.', success: '' });
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setStatus({ error: 'The new password and confirmation do not match.', success: '' });
+      return;
+    }
+    try {
+      setSubmitting(true);
+      await onSubmit({ currentPassword, newPassword });
+      setStatus({ error: '', success: 'Password updated successfully.' });
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err) {
+      setStatus({ error: err.message || 'Unable to update password.', success: '' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="panel" onSubmit={handleSubmit}>
+      <div className="panel-header">
+        <h2>{title}</h2>
+        <p>Update your account password to keep your storage secure.</p>
+      </div>
+      {status.error && (
+        <div className="alert error" role="alert">
+          {status.error}
+        </div>
+      )}
+      {status.success && (
+        <div className="alert success" role="status">
+          {status.success}
+        </div>
+      )}
+      <div className="panel-content grid">
+        <label className="field">
+          <span>Current password</span>
+          <input
+            type="password"
+            value={currentPassword}
+            onChange={(event) => setCurrentPassword(event.target.value)}
+            autoComplete="current-password"
+            placeholder="Current password"
+          />
+        </label>
+        <label className="field">
+          <span>New password</span>
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            autoComplete="new-password"
+            placeholder="New password"
+          />
+        </label>
+        <label className="field">
+          <span>Confirm new password</span>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            autoComplete="new-password"
+            placeholder="Confirm password"
+          />
+        </label>
+      </div>
+      <div className="panel-actions">
+        <button type="submit" className="button" disabled={submitting}>
+          {submitting ? 'Updating…' : 'Update Password'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default ChangePasswordForm;

--- a/frontend/src/components/FileList.jsx
+++ b/frontend/src/components/FileList.jsx
@@ -57,6 +57,10 @@ const FileList = ({
   onDelete,
   onToggleLock,
   onDownload,
+  allowRename = true,
+  allowDelete = true,
+  allowLockToggle = true,
+  allowQuickLook = true,
 }) => {
   if (!items || items.length === 0) {
     return <div className="empty-state">This folder is empty.</div>;
@@ -86,7 +90,7 @@ const FileList = ({
               onSelect(item);
               if (isDirectory) {
                 onOpen(item);
-              } else {
+              } else if (allowQuickLook) {
                 onQuickLook(item);
               }
             }}
@@ -94,11 +98,11 @@ const FileList = ({
               if (event.key === 'Enter') {
                 if (isDirectory) {
                   onOpen(item);
-                } else {
+                } else if (allowQuickLook) {
                   onQuickLook(item);
                 }
               }
-              if (event.key === ' ' && !isDirectory) {
+              if (event.key === ' ' && !isDirectory && allowQuickLook) {
                 event.preventDefault();
                 onQuickLook(item);
               }
@@ -127,17 +131,19 @@ const FileList = ({
                 </button>
               ) : (
                 <>
-                  <button
-                    type="button"
-                    className="pill-button"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      onSelect(item);
-                      onQuickLook(item);
-                    }}
-                  >
-                    Quick Look
-                  </button>
+                  {allowQuickLook && (
+                    <button
+                      type="button"
+                      className="pill-button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSelect(item);
+                        onQuickLook(item);
+                      }}
+                    >
+                      Quick Look
+                    </button>
+                  )}
                   <button
                     type="button"
                     className="pill-button"
@@ -151,39 +157,45 @@ const FileList = ({
                   </button>
                 </>
               )}
-              <button
-                type="button"
-                className="pill-button subtle"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelect(item);
-                  onRename(item);
-                }}
-              >
-                Rename
-              </button>
-              <button
-                type="button"
-                className="pill-button danger"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelect(item);
-                  onDelete(item);
-                }}
-              >
-                Delete
-              </button>
-              <button
-                type="button"
-                className="pill-button subtle"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onSelect(item);
-                  onToggleLock(item);
-                }}
-              >
-                {item.isLocked ? 'Unlock' : 'Lock'}
-              </button>
+              {allowRename && (
+                <button
+                  type="button"
+                  className="pill-button subtle"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelect(item);
+                    onRename(item);
+                  }}
+                >
+                  Rename
+                </button>
+              )}
+              {allowDelete && (
+                <button
+                  type="button"
+                  className="pill-button danger"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelect(item);
+                    onDelete(item);
+                  }}
+                >
+                  Delete
+                </button>
+              )}
+              {allowLockToggle && (
+                <button
+                  type="button"
+                  className="pill-button subtle"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelect(item);
+                    onToggleLock(item);
+                  }}
+                >
+                  {item.isLocked ? 'Unlock' : 'Lock'}
+                </button>
+              )}
             </div>
           </div>
         );
@@ -223,7 +235,7 @@ const FileList = ({
                 onSelect(item);
                 if (isDirectory) {
                   onOpen(item);
-                } else {
+                } else if (allowQuickLook) {
                   onQuickLook(item);
                 }
               }}
@@ -231,11 +243,11 @@ const FileList = ({
                 if (event.key === 'Enter') {
                   if (isDirectory) {
                     onOpen(item);
-                  } else {
+                  } else if (allowQuickLook) {
                     onQuickLook(item);
                   }
                 }
-                if (event.key === ' ' && !isDirectory) {
+                if (event.key === ' ' && !isDirectory && allowQuickLook) {
                   event.preventDefault();
                   onQuickLook(item);
                 }
@@ -266,17 +278,19 @@ const FileList = ({
                   </button>
                 ) : (
                   <>
-                    <button
-                      type="button"
-                      className="link"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onSelect(item);
-                        onQuickLook(item);
-                      }}
-                    >
-                      Quick Look
-                    </button>
+                    {allowQuickLook && (
+                      <button
+                        type="button"
+                        className="link"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onSelect(item);
+                          onQuickLook(item);
+                        }}
+                      >
+                        Quick Look
+                      </button>
+                    )}
                     <button
                       type="button"
                       className="link"
@@ -290,39 +304,45 @@ const FileList = ({
                     </button>
                   </>
                 )}
-                <button
-                  type="button"
-                  className="link"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelect(item);
-                    onRename(item);
-                  }}
-                >
-                  Rename
-                </button>
-                <button
-                  type="button"
-                  className="link warning"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelect(item);
-                    onDelete(item);
-                  }}
-                >
-                  Delete
-                </button>
-                <button
-                  type="button"
-                  className="link"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onSelect(item);
-                    onToggleLock(item);
-                  }}
-                >
-                  {lockIcon} {item.isLocked ? 'Unlock' : 'Lock'}
-                </button>
+                {allowRename && (
+                  <button
+                    type="button"
+                    className="link"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSelect(item);
+                      onRename(item);
+                    }}
+                  >
+                    Rename
+                  </button>
+                )}
+                {allowDelete && (
+                  <button
+                    type="button"
+                    className="link warning"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSelect(item);
+                      onDelete(item);
+                    }}
+                  >
+                    Delete
+                  </button>
+                )}
+                {allowLockToggle && (
+                  <button
+                    type="button"
+                    className="link"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onSelect(item);
+                      onToggleLock(item);
+                    }}
+                  >
+                    {lockIcon} {item.isLocked ? 'Unlock' : 'Lock'}
+                  </button>
+                )}
               </td>
             </tr>
           );

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -1,0 +1,615 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Breadcrumbs from './Breadcrumbs.jsx';
+import FileList from './FileList.jsx';
+import QuickLook from './QuickLook.jsx';
+import Toolbar from './Toolbar.jsx';
+import {
+  listItems,
+  createFolder,
+  uploadFiles,
+  deleteItem,
+  renameItem,
+  lockItem,
+  unlockItem,
+  fetchFileContent,
+} from '../services/api.js';
+
+const sanitizePath = (input) => {
+  if (typeof input !== 'string') {
+    return '';
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed
+    .replace(/\\/g, '/')
+    .replace(/\/+/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+};
+
+const joinPath = (base, name) => {
+  const sanitizedBase = sanitizePath(base);
+  if (!sanitizedBase) {
+    return name;
+  }
+  return `${sanitizedBase}/${name}`;
+};
+
+const initialQuickLookState = {
+  open: false,
+  loading: false,
+  error: '',
+  url: '',
+  mimeType: '',
+  textContent: '',
+  item: null,
+};
+
+const FileManager = ({
+  title = 'HTS NAS',
+  subtitle = 'Browse, organize, and secure your shared storage.',
+  initialPath = '',
+  rootPath = '',
+  allowCreate = true,
+  allowUpload = true,
+  allowRename = true,
+  allowDelete = true,
+  allowLockToggle = true,
+  allowQuickLook = true,
+  allowViewToggle = true,
+  passwordLookup,
+}) => {
+  const normalizedRoot = useMemo(() => sanitizePath(rootPath), [rootPath]);
+  const normalizedInitial = useMemo(() => sanitizePath(initialPath), [initialPath]);
+  const startingPath = normalizedInitial || normalizedRoot || '';
+
+  const [currentPath, setCurrentPath] = useState(startingPath);
+  const [items, setItems] = useState([]);
+  const [breadcrumbs, setBreadcrumbs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [viewMode, setViewMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.localStorage.getItem('hts-view-mode') || 'grid';
+    }
+    return 'grid';
+  });
+  const [selectedItem, setSelectedItem] = useState(null);
+  const [quickLook, setQuickLook] = useState(initialQuickLookState);
+  const previewUrlRef = useRef('');
+
+  useEffect(() => {
+    setCurrentPath(startingPath);
+  }, [startingPath]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError('');
+
+    listItems(currentPath)
+      .then((data) => {
+        if (!active) {
+          return;
+        }
+        const nextItems = data.items || [];
+        setItems(nextItems);
+        setBreadcrumbs(data.breadcrumbs || []);
+        const normalizedPath = data.path || '';
+        if (normalizedPath !== currentPath) {
+          setCurrentPath(normalizedPath);
+        }
+      })
+      .catch((err) => {
+        if (!active) {
+          return;
+        }
+        setError(err.message || 'Failed to load items');
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [currentPath, refreshToken]);
+
+  useEffect(() => {
+    if (!message) {
+      return undefined;
+    }
+    const timeout = setTimeout(() => setMessage(''), 4000);
+    return () => clearTimeout(timeout);
+  }, [message]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('hts-view-mode', viewMode);
+    }
+  }, [viewMode]);
+
+  useEffect(() => {
+    setSelectedItem(null);
+  }, [currentPath]);
+
+  useEffect(() => {
+    setSelectedItem((current) => {
+      if (!current) {
+        return current;
+      }
+      return items.find((item) => item.path === current.path) || null;
+    });
+  }, [items]);
+
+  useEffect(
+    () => () => {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!quickLook.open || !quickLook.item) {
+      return;
+    }
+    const exists = items.some((item) => item.path === quickLook.item.path);
+    if (!exists) {
+      if (previewUrlRef.current) {
+        URL.revokeObjectURL(previewUrlRef.current);
+        previewUrlRef.current = '';
+      }
+      setQuickLook(initialQuickLookState);
+    }
+  }, [items, quickLook.open, quickLook.item]);
+
+  const isWithinRoot = useMemo(() => {
+    if (!normalizedRoot) {
+      return () => true;
+    }
+    return (candidate) => {
+      const sanitizedCandidate = sanitizePath(candidate);
+      if (!sanitizedCandidate) {
+        return normalizedRoot === '';
+      }
+      if (sanitizedCandidate === normalizedRoot) {
+        return true;
+      }
+      return sanitizedCandidate.startsWith(`${normalizedRoot}/`);
+    };
+  }, [normalizedRoot]);
+
+  const refresh = () => {
+    setRefreshToken((token) => token + 1);
+  };
+
+  const updatePath = (path) => {
+    const sanitized = sanitizePath(path);
+    if (!isWithinRoot(sanitized)) {
+      setError('You can only browse within your assigned folder.');
+      return;
+    }
+    setError('');
+    setCurrentPath(sanitized);
+  };
+
+  const handleNavigate = (path) => {
+    updatePath(path || '');
+  };
+
+  const parentPath = useMemo(() => {
+    if (!currentPath) {
+      return '';
+    }
+    const segments = currentPath.split('/');
+    segments.pop();
+    return segments.join('/');
+  }, [currentPath]);
+
+  const canNavigateUp = useMemo(() => {
+    if (!currentPath) {
+      return false;
+    }
+    if (!normalizedRoot) {
+      return Boolean(currentPath);
+    }
+    return currentPath !== normalizedRoot && isWithinRoot(currentPath);
+  }, [currentPath, normalizedRoot, isWithinRoot]);
+
+  const handleNavigateUp = () => {
+    if (!currentPath) {
+      return;
+    }
+    if (!normalizedRoot) {
+      updatePath(parentPath);
+      return;
+    }
+    if (!parentPath) {
+      updatePath(normalizedRoot);
+      return;
+    }
+    if (!isWithinRoot(parentPath)) {
+      updatePath(normalizedRoot);
+      return;
+    }
+    updatePath(parentPath);
+  };
+
+  const performAction = async (action, successMessage) => {
+    try {
+      setError('');
+      setMessage('');
+      await action();
+      if (successMessage) {
+        setMessage(successMessage);
+      }
+      refresh();
+    } catch (err) {
+      setError(err.message || 'Something went wrong');
+    }
+  };
+
+  const getStoredPassword = (path) => {
+    if (!passwordLookup) {
+      return undefined;
+    }
+    const sanitized = sanitizePath(path);
+    if (!sanitized) {
+      return undefined;
+    }
+    return passwordLookup(sanitized);
+  };
+
+  const handleCreateFolder = async () => {
+    if (!allowCreate) {
+      return;
+    }
+    const name = window.prompt('Folder name');
+    if (!name) {
+      return;
+    }
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Folder name cannot be empty');
+      return;
+    }
+    await performAction(
+      () => createFolder(currentPath, trimmed),
+      `Folder “${trimmed}” created`
+    );
+  };
+
+  const handleUpload = async (files) => {
+    if (!allowUpload) {
+      return;
+    }
+    if (!files || files.length === 0) {
+      return;
+    }
+    await performAction(
+      () => uploadFiles(currentPath, files),
+      files.length === 1 ? `Uploaded “${files[0].name}”` : `Uploaded ${files.length} files`
+    );
+  };
+
+  const handleOpen = (item) => {
+    if (item.type === 'directory') {
+      handleNavigate(item.path || joinPath(currentPath, item.name));
+    }
+  };
+
+  const handleDelete = async (item) => {
+    if (!allowDelete) {
+      return;
+    }
+    const confirmed = window.confirm(
+      `Delete ${item.type === 'directory' ? 'folder' : 'file'} “${item.name}”?`
+    );
+    if (!confirmed) {
+      return;
+    }
+    let password;
+    if (item.isLocked) {
+      password = getStoredPassword(item.path || joinPath(currentPath, item.name));
+      if (!password) {
+        password = window.prompt('Enter the password to delete this locked item');
+      }
+      if (!password) {
+        setMessage('Deletion cancelled');
+        return;
+      }
+    }
+
+    await performAction(
+      () => deleteItem(item.path || joinPath(currentPath, item.name), password || undefined),
+      `Deleted “${item.name}”`
+    );
+  };
+
+  const handleRename = async (item) => {
+    if (!allowRename) {
+      return;
+    }
+    const newName = window.prompt('Enter the new name', item.name);
+    if (!newName) {
+      return;
+    }
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      setError('New name cannot be empty');
+      return;
+    }
+    if (trimmed === item.name) {
+      return;
+    }
+
+    let password;
+    if (item.isLocked) {
+      password = getStoredPassword(item.path || joinPath(currentPath, item.name));
+      if (!password) {
+        password = window.prompt('Enter the password to rename this locked item');
+      }
+      if (!password) {
+        setMessage('Rename cancelled');
+        return;
+      }
+    }
+
+    await performAction(
+      () => renameItem(item.path || joinPath(currentPath, item.name), trimmed, password || undefined),
+      `Renamed to “${trimmed}”`
+    );
+  };
+
+  const handleToggleLock = async (item) => {
+    if (!allowLockToggle) {
+      return;
+    }
+    const targetPath = item.path || joinPath(currentPath, item.name);
+    if (item.isLocked) {
+      const stored = getStoredPassword(targetPath);
+      const password = stored || window.prompt('Enter the password to unlock this item');
+      if (!password) {
+        setMessage('Unlock cancelled');
+        return;
+      }
+      await performAction(
+        () => unlockItem(targetPath, password),
+        `Unlocked “${item.name}”`
+      );
+      return;
+    }
+
+    const password = window.prompt('Set a password to lock this item');
+    if (!password) {
+      setMessage('Lock cancelled');
+      return;
+    }
+    await performAction(
+      () => lockItem(targetPath, password),
+      `Locked “${item.name}”`
+    );
+  };
+
+  const handleSelectItem = (item) => {
+    setSelectedItem(item);
+  };
+
+  const closeQuickLook = () => {
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = '';
+    }
+    setQuickLook(initialQuickLookState);
+  };
+
+  const handleQuickLook = async (targetItem) => {
+    if (!allowQuickLook) {
+      return;
+    }
+    const item = targetItem || selectedItem;
+    if (!item || item.type !== 'file') {
+      return;
+    }
+
+    let password;
+    if (item.isLocked) {
+      password = getStoredPassword(item.path || joinPath(currentPath, item.name));
+      if (!password) {
+        const input = window.prompt('Enter the password to preview this locked file');
+        if (!input) {
+          setMessage('Preview cancelled');
+          return;
+        }
+        password = input;
+      }
+    }
+
+    setError('');
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = '';
+    }
+
+    setQuickLook({
+      open: true,
+      loading: true,
+      error: '',
+      url: '',
+      mimeType: '',
+      textContent: '',
+      item,
+    });
+
+    try {
+      const { blob, contentType } = await fetchFileContent(
+        item.path || joinPath(currentPath, item.name),
+        {
+          password,
+        }
+      );
+      let textContent = '';
+      if (contentType.startsWith('text/') || contentType === 'application/json') {
+        textContent = await blob.text();
+      }
+      const objectUrl = URL.createObjectURL(blob);
+      previewUrlRef.current = objectUrl;
+      setQuickLook({
+        open: true,
+        loading: false,
+        error: '',
+        url: objectUrl,
+        mimeType: contentType,
+        textContent,
+        item,
+      });
+    } catch (err) {
+      setQuickLook({
+        open: true,
+        loading: false,
+        error: err.message || 'Unable to preview file',
+        url: '',
+        mimeType: '',
+        textContent: '',
+        item,
+      });
+    }
+  };
+
+  const handleDownload = async (item) => {
+    if (!item || item.type !== 'file') {
+      return;
+    }
+
+    let password;
+    if (item.isLocked) {
+      password = getStoredPassword(item.path || joinPath(currentPath, item.name));
+      if (!password) {
+        const input = window.prompt('Enter the password to download this locked file');
+        if (!input) {
+          setMessage('Download cancelled');
+          return;
+        }
+        password = input;
+      }
+    }
+
+    try {
+      setError('');
+      const { blob, filename } = await fetchFileContent(
+        item.path || joinPath(currentPath, item.name),
+        {
+          password,
+          download: true,
+        }
+      );
+      const downloadUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = downloadUrl;
+      anchor.download = filename || item.name;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(downloadUrl);
+      setMessage(`Download started for “${filename || item.name}”`);
+    } catch (err) {
+      setError(err.message || 'Unable to download file');
+    }
+  };
+
+  const handleOpenPreviewInNewTab = () => {
+    if (!quickLook.url) {
+      return;
+    }
+    const opened = window.open(quickLook.url, '_blank', 'noopener');
+    if (!opened) {
+      setError('Unable to open the preview in a new tab. Please allow pop-ups for this site.');
+    }
+  };
+
+  const canQuickLook = allowQuickLook && selectedItem?.type === 'file';
+  const quickLookDownloadHandler = quickLook.item ? () => handleDownload(quickLook.item) : undefined;
+
+  return (
+    <div className="file-manager">
+      <header className="app-header">
+        <h1>{title}</h1>
+        {subtitle ? <p className="subtitle">{subtitle}</p> : null}
+      </header>
+
+      <Toolbar
+        currentPath={currentPath}
+        onCreateFolder={handleCreateFolder}
+        onUpload={handleUpload}
+        onRefresh={refresh}
+        onNavigateUp={handleNavigateUp}
+        canNavigateUp={canNavigateUp}
+        onQuickLook={() => handleQuickLook()}
+        canQuickLook={canQuickLook}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        allowCreate={allowCreate}
+        allowUpload={allowUpload}
+        allowQuickLook={allowQuickLook}
+        allowViewToggle={allowViewToggle}
+      />
+
+      <Breadcrumbs breadcrumbs={breadcrumbs} onNavigate={handleNavigate} />
+
+      {error && (
+        <div className="alert error" role="alert">
+          {error}
+        </div>
+      )}
+      {message && (
+        <div className="alert success" role="status">
+          {message}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="loading">Loading…</div>
+      ) : (
+        <FileList
+          items={items}
+          viewMode={viewMode}
+          selectedItem={selectedItem}
+          onSelect={handleSelectItem}
+          onOpen={handleOpen}
+          onQuickLook={handleQuickLook}
+          onRename={handleRename}
+          onDelete={handleDelete}
+          onToggleLock={handleToggleLock}
+          onDownload={handleDownload}
+          allowRename={allowRename}
+          allowDelete={allowDelete}
+          allowLockToggle={allowLockToggle}
+          allowQuickLook={allowQuickLook}
+        />
+      )}
+
+      <QuickLook
+        isOpen={quickLook.open}
+        item={quickLook.item}
+        previewUrl={quickLook.url}
+        mimeType={quickLook.mimeType}
+        textContent={quickLook.textContent}
+        loading={quickLook.loading}
+        error={quickLook.error}
+        onClose={closeQuickLook}
+        onDownload={quickLookDownloadHandler}
+        onOpenInNewTab={handleOpenPreviewInNewTab}
+      />
+    </div>
+  );
+};
+
+export default FileManager;

--- a/frontend/src/components/LoginForm.jsx
+++ b/frontend/src/components/LoginForm.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+const LoginForm = ({ onSubmit, error }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [localError, setLocalError] = useState('');
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!username.trim() || !password) {
+      setLocalError('Please enter both username and password.');
+      return;
+    }
+    setLocalError('');
+    onSubmit({ username: username.trim(), password });
+  };
+
+  return (
+    <form className="auth-card" onSubmit={handleSubmit}>
+      <h1>Sign in to HTS NAS</h1>
+      <p className="auth-subtitle">Enter your account credentials to access the dashboard.</p>
+      {(error || localError) && (
+        <div className="alert error" role="alert">
+          {error || localError}
+        </div>
+      )}
+      <label className="field">
+        <span>Username</span>
+        <input
+          type="text"
+          value={username}
+          onChange={(event) => setUsername(event.target.value)}
+          autoComplete="username"
+          placeholder="e.g. Admin"
+        />
+      </label>
+      <label className="field">
+        <span>Password</span>
+        <input
+          type="password"
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+          autoComplete="current-password"
+          placeholder="Your password"
+        />
+      </label>
+      <button type="submit" className="button primary-button">
+        Sign In
+      </button>
+      <p className="login-hint">
+        Try the default admin account: <strong>Admin / HTS</strong>
+      </p>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/frontend/src/components/Toolbar.jsx
+++ b/frontend/src/components/Toolbar.jsx
@@ -11,10 +11,17 @@ const Toolbar = ({
   canQuickLook,
   viewMode,
   onViewModeChange,
+  allowCreate = true,
+  allowUpload = true,
+  allowQuickLook = true,
+  allowViewToggle = true,
 }) => {
   const inputRef = useRef(null);
 
   const handleUploadClick = () => {
+    if (!allowUpload) {
+      return;
+    }
     inputRef.current?.click();
   };
 
@@ -40,38 +47,46 @@ const Toolbar = ({
         <span className="toolbar-path">{currentPath || 'Home'}</span>
       </div>
       <div className="toolbar-actions">
-        <div className="view-toggle" role="group" aria-label="Change view">
+        {allowViewToggle && (
+          <div className="view-toggle" role="group" aria-label="Change view">
+            <button
+              type="button"
+              className={`view-button${viewMode === 'grid' ? ' active' : ''}`}
+              onClick={() => onViewModeChange('grid')}
+              aria-label="Icon view"
+            >
+              🗂️
+            </button>
+            <button
+              type="button"
+              className={`view-button${viewMode === 'list' ? ' active' : ''}`}
+              onClick={() => onViewModeChange('list')}
+              aria-label="List view"
+            >
+              📄
+            </button>
+          </div>
+        )}
+        {allowQuickLook && (
           <button
             type="button"
-            className={`view-button${viewMode === 'grid' ? ' active' : ''}`}
-            onClick={() => onViewModeChange('grid')}
-            aria-label="Icon view"
+            className="button secondary"
+            onClick={onQuickLook}
+            disabled={!canQuickLook}
           >
-            🗂️
+            👁️ Quick Look
           </button>
-          <button
-            type="button"
-            className={`view-button${viewMode === 'list' ? ' active' : ''}`}
-            onClick={() => onViewModeChange('list')}
-            aria-label="List view"
-          >
-            📄
+        )}
+        {allowCreate && (
+          <button type="button" className="button" onClick={onCreateFolder}>
+            📁 New Folder
           </button>
-        </div>
-        <button
-          type="button"
-          className="button secondary"
-          onClick={onQuickLook}
-          disabled={!canQuickLook}
-        >
-          👁️ Quick Look
-        </button>
-        <button type="button" className="button" onClick={onCreateFolder}>
-          📁 New Folder
-        </button>
-        <button type="button" className="button" onClick={handleUploadClick}>
-          ⬆️ Upload Files
-        </button>
+        )}
+        {allowUpload && (
+          <button type="button" className="button" onClick={handleUploadClick}>
+            ⬆️ Upload Files
+          </button>
+        )}
         <button type="button" className="button" onClick={onRefresh}>
           🔄 Refresh
         </button>

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useMemo, useState } from 'react';
+import FileManager from './FileManager.jsx';
+import AccessList from './AccessList.jsx';
+import ChangePasswordForm from './ChangePasswordForm.jsx';
+
+const normalizePath = (input) => {
+  if (typeof input !== 'string') {
+    return '';
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed
+    .replace(/\\/g, '/')
+    .replace(/\/+/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+};
+
+const UserDashboard = ({ user, onLogout, onPasswordChange }) => {
+  const accessList = Array.isArray(user.access) ? user.access : [];
+  const [selectedPath, setSelectedPath] = useState(accessList[0]?.path || '');
+
+  useEffect(() => {
+    setSelectedPath(accessList[0]?.path || '');
+  }, [user.username, accessList]);
+
+  const passwordLookup = useMemo(() => {
+    return (path) => {
+      const normalized = normalizePath(path);
+      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
+      return match?.password;
+    };
+  }, [accessList]);
+
+  const hasAssignedAccess = accessList.length > 0;
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard-header">
+        <div>
+          <h1>Welcome, {user.username}</h1>
+          <p className="muted">Browse and manage the folders shared with your account.</p>
+        </div>
+        <button type="button" className="button danger" onClick={onLogout}>
+          Sign out
+        </button>
+      </header>
+
+      <section className="dashboard-section">
+        <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
+      </section>
+
+      {hasAssignedAccess && (
+        <section className="dashboard-section">
+          <FileManager
+            title="Your file explorer"
+            subtitle="All changes you make stay within your assigned folders."
+            initialPath={selectedPath}
+            rootPath={selectedPath}
+            allowLockToggle={false}
+            passwordLookup={passwordLookup}
+          />
+        </section>
+      )}
+
+      <section className="dashboard-section">
+        <ChangePasswordForm title="Update your password" onSubmit={onPasswordChange} />
+      </section>
+    </div>
+  );
+};
+
+export default UserDashboard;

--- a/frontend/src/components/UserManagementPanel.jsx
+++ b/frontend/src/components/UserManagementPanel.jsx
@@ -1,0 +1,403 @@
+import { useEffect, useState } from 'react';
+import { fetchUsers, createUser, updateUser, deleteUser } from '../services/api.js';
+
+const normalizePath = (input) => {
+  if (typeof input !== 'string') {
+    return '';
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed
+    .replace(/\\/g, '/')
+    .replace(/\/+/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+};
+
+const initialNewUser = {
+  username: '',
+  password: '',
+  role: 'user',
+};
+
+const UserManagementPanel = ({ onUsersChanged }) => {
+  const [users, setUsers] = useState([]);
+  const [selectedUsername, setSelectedUsername] = useState('');
+  const [accessDraft, setAccessDraft] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [newUser, setNewUser] = useState(initialNewUser);
+  const [savingAccess, setSavingAccess] = useState(false);
+  const [updatingUser, setUpdatingUser] = useState(false);
+
+  const loadUsers = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchUsers();
+      const sorted = (data.users || []).slice().sort((a, b) => a.username.localeCompare(b.username));
+      setUsers(sorted);
+      if (sorted.length === 0) {
+        setSelectedUsername('');
+        setAccessDraft([]);
+        return;
+      }
+      const existing = sorted.find((user) => user.username === selectedUsername);
+      const activeUser = existing || sorted[0];
+      setSelectedUsername(activeUser.username);
+      setAccessDraft(activeUser.access ? activeUser.access.map((entry) => ({ ...entry })) : []);
+    } catch (err) {
+      setError(err.message || 'Unable to load users.');
+      setUsers([]);
+      setSelectedUsername('');
+      setAccessDraft([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  useEffect(() => {
+    if (!message) {
+      return undefined;
+    }
+    const timeout = setTimeout(() => setMessage(''), 4000);
+    return () => clearTimeout(timeout);
+  }, [message]);
+
+  const selectedUser = users.find((user) => user.username === selectedUsername) || null;
+
+  const handleSelectUser = (username) => {
+    setSelectedUsername(username);
+    const target = users.find((user) => user.username === username);
+    setAccessDraft(target?.access ? target.access.map((entry) => ({ ...entry })) : []);
+  };
+
+  const handleAccessChange = (index, field, value) => {
+    setAccessDraft((entries) =>
+      entries.map((entry, idx) => (idx === index ? { ...entry, [field]: value } : entry))
+    );
+  };
+
+  const handleRemoveAccess = (index) => {
+    setAccessDraft((entries) => entries.filter((_, idx) => idx !== index));
+  };
+
+  const handleAddAccess = () => {
+    setAccessDraft((entries) => [...entries, { path: '', password: '' }]);
+  };
+
+  const handleSaveAccess = async () => {
+    if (!selectedUser) {
+      return;
+    }
+    setError('');
+    setMessage('');
+    const formatted = accessDraft.map((entry) => ({
+      path: normalizePath(entry.path || ''),
+      password: (entry.password || '').trim(),
+    }));
+    if (formatted.some((entry) => !entry.password)) {
+      setError('Every folder access must include a password.');
+      return;
+    }
+    setSavingAccess(true);
+    try {
+      await updateUser(selectedUser.username, { access: formatted });
+      setMessage('Updated folder access.');
+      await loadUsers();
+      onUsersChanged?.();
+    } catch (err) {
+      setError(err.message || 'Unable to update folder access.');
+    } finally {
+      setSavingAccess(false);
+    }
+  };
+
+  const handleRoleChange = async (event) => {
+    const role = event.target.value;
+    if (!selectedUser || role === selectedUser.role) {
+      return;
+    }
+    setError('');
+    setMessage('');
+    setUpdatingUser(true);
+    try {
+      await updateUser(selectedUser.username, { role });
+      setMessage(`Updated role for ${selectedUser.username}.`);
+      await loadUsers();
+      onUsersChanged?.();
+    } catch (err) {
+      setError(err.message || 'Unable to update role.');
+    } finally {
+      setUpdatingUser(false);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (!selectedUser) {
+      return;
+    }
+    setError('');
+    setMessage('');
+    const password = window.prompt(`Enter a new password for ${selectedUser.username}`);
+    if (!password) {
+      setMessage('Password update cancelled.');
+      return;
+    }
+    if (password.length < 4) {
+      setError('Password must be at least 4 characters long.');
+      return;
+    }
+    setUpdatingUser(true);
+    try {
+      await updateUser(selectedUser.username, { password });
+      setMessage(`Password updated for ${selectedUser.username}.`);
+      await loadUsers();
+      onUsersChanged?.();
+    } catch (err) {
+      setError(err.message || 'Unable to reset password.');
+    } finally {
+      setUpdatingUser(false);
+    }
+  };
+
+  const handleDeleteUser = async () => {
+    if (!selectedUser || selectedUser.username === 'Admin') {
+      return;
+    }
+    setError('');
+    setMessage('');
+    const confirmed = window.confirm(`Remove user “${selectedUser.username}”?`);
+    if (!confirmed) {
+      return;
+    }
+    setUpdatingUser(true);
+    try {
+      await deleteUser(selectedUser.username);
+      setMessage(`Removed ${selectedUser.username}.`);
+      await loadUsers();
+      onUsersChanged?.();
+    } catch (err) {
+      setError(err.message || 'Unable to delete user.');
+    } finally {
+      setUpdatingUser(false);
+    }
+  };
+
+  const handleCreateUser = async (event) => {
+    event.preventDefault();
+    const username = newUser.username.trim();
+    const password = newUser.password;
+    const role = newUser.role === 'admin' ? 'admin' : 'user';
+    setError('');
+    setMessage('');
+    if (!username || !password) {
+      setError('Username and password are required to create a user.');
+      return;
+    }
+    if (password.length < 4) {
+      setError('Password must be at least 4 characters long.');
+      return;
+    }
+    setCreating(true);
+    try {
+      await createUser({ username, password, role });
+      setMessage(`Created user ${username}.`);
+      setNewUser(initialNewUser);
+      await loadUsers();
+      onUsersChanged?.();
+    } catch (err) {
+      setError(err.message || 'Unable to create user.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="user-management-wrapper">
+      <div className="panel user-management-panel">
+        <div className="panel-header">
+          <h2>User management</h2>
+          <p>Review accounts, assign folder access, and manage credentials.</p>
+        </div>
+        {error && (
+          <div className="alert error" role="alert">
+            {error}
+          </div>
+        )}
+        {message && (
+          <div className="alert success" role="status">
+            {message}
+          </div>
+        )}
+        <div className="panel-content user-management">
+          <div className="user-list">
+            {loading ? (
+              <div className="loading small">Loading users…</div>
+            ) : (
+              <ul>
+                {users.map((user) => (
+                  <li key={user.username}>
+                    <button
+                      type="button"
+                      className={`user-tab${user.username === selectedUsername ? ' active' : ''}`}
+                      onClick={() => handleSelectUser(user.username)}
+                    >
+                      <span>{user.username}</span>
+                      <span className="badge">{user.role}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <div className="user-details">
+            {selectedUser ? (
+              <>
+                <div className="user-summary">
+                  <div>
+                    <h3>{selectedUser.username}</h3>
+                    <p className="muted">
+                      Created {selectedUser.createdAt ? new Date(selectedUser.createdAt).toLocaleString() : '—'}
+                    </p>
+                    <p className="muted">
+                      Updated {selectedUser.updatedAt ? new Date(selectedUser.updatedAt).toLocaleString() : '—'}
+                    </p>
+                  </div>
+                  <label className="field">
+                    <span>Role</span>
+                    <select
+                      value={selectedUser.role}
+                      onChange={handleRoleChange}
+                      disabled={updatingUser || selectedUser.username === 'Admin'}
+                    >
+                      <option value="user">User</option>
+                      <option value="admin">Admin</option>
+                    </select>
+                  </label>
+                </div>
+                <div className="access-editor">
+                  <h4>Folder access</h4>
+                  {accessDraft.length === 0 && <p className="muted">No folders assigned yet.</p>}
+                  {accessDraft.map((entry, index) => (
+                    <div className="access-editor-row" key={`${entry.path}-${index}`}>
+                      <input
+                        type="text"
+                        value={entry.path}
+                        onChange={(event) => handleAccessChange(index, 'path', event.target.value)}
+                        placeholder="Folder path (e.g. Projects/TeamA)"
+                      />
+                      <input
+                        type="text"
+                        value={entry.password}
+                        onChange={(event) => handleAccessChange(index, 'password', event.target.value)}
+                        placeholder="Password"
+                      />
+                      <button
+                        type="button"
+                        className="button subtle"
+                        onClick={() => handleRemoveAccess(index)}
+                        disabled={savingAccess}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                  <div className="access-editor-actions">
+                    <button
+                      type="button"
+                      className="button secondary"
+                      onClick={handleAddAccess}
+                      disabled={savingAccess}
+                    >
+                      Add folder
+                    </button>
+                    <button
+                      type="button"
+                      className="button"
+                      onClick={handleSaveAccess}
+                      disabled={savingAccess}
+                    >
+                      {savingAccess ? 'Saving…' : 'Save access'}
+                    </button>
+                  </div>
+                </div>
+                <div className="user-actions">
+                  <button
+                    type="button"
+                    className="button secondary"
+                    onClick={handleResetPassword}
+                    disabled={updatingUser}
+                  >
+                    Reset password
+                  </button>
+                  <button
+                    type="button"
+                    className="button danger"
+                    onClick={handleDeleteUser}
+                    disabled={selectedUser.username === 'Admin' || updatingUser}
+                  >
+                    Delete user
+                  </button>
+                </div>
+              </>
+            ) : (
+              <p className="muted">Select a user to view details.</p>
+            )}
+          </div>
+        </div>
+      </div>
+      <form className="panel create-user-panel" onSubmit={handleCreateUser}>
+        <div className="panel-header">
+          <h2>Create new user</h2>
+          <p>Add a new account and assign access later.</p>
+        </div>
+        <div className="panel-content grid">
+          <label className="field">
+            <span>Username</span>
+            <input
+              type="text"
+              value={newUser.username}
+              onChange={(event) => setNewUser((state) => ({ ...state, username: event.target.value }))}
+              placeholder="Unique username"
+            />
+          </label>
+          <label className="field">
+            <span>Password</span>
+            <input
+              type="password"
+              value={newUser.password}
+              onChange={(event) => setNewUser((state) => ({ ...state, password: event.target.value }))}
+              placeholder="Temporary password"
+            />
+          </label>
+          <label className="field">
+            <span>Role</span>
+            <select
+              value={newUser.role}
+              onChange={(event) => setNewUser((state) => ({ ...state, role: event.target.value }))}
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          </label>
+        </div>
+        <div className="panel-actions">
+          <button type="submit" className="button" disabled={creating}>
+            {creating ? 'Creating…' : 'Create user'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default UserManagementPanel;

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -600,3 +600,337 @@ body {
     padding: 1rem;
   }
 }
+.app-container {
+  gap: 1.5rem;
+}
+
+.app-container.centered {
+  min-height: 100vh;
+  justify-content: center;
+  align-items: center;
+}
+
+.auth-layout {
+  max-width: 460px;
+  width: 100%;
+}
+
+.dashboard-container {
+  max-width: 1200px;
+  width: 100%;
+}
+
+.button.danger {
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.button.danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.button.subtle {
+  background: rgba(107, 114, 128, 0.12);
+  color: #374151;
+  box-shadow: none;
+}
+
+.button.subtle:hover:not(:disabled) {
+  background: rgba(107, 114, 128, 0.22);
+}
+
+.file-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #ffffff;
+  padding: 1.5rem;
+  border-radius: 20px;
+  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.4);
+  gap: 1rem;
+}
+
+.dashboard-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.dashboard-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.muted {
+  color: #6b7280;
+  margin: 0;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 25px 60px -45px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.panel-header p {
+  margin: 0.25rem 0 0;
+  color: #6b7280;
+}
+
+.panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-content.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.panel-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.auth-card {
+  width: 100%;
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 2.25rem 2rem;
+  box-shadow: 0 35px 70px -40px rgba(37, 99, 235, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.auth-card h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.auth-subtitle {
+  margin: 0;
+  color: #6b7280;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field input,
+.field select {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.login-hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.95rem;
+}
+
+.primary-button {
+  width: 100%;
+}
+
+.user-management-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.user-management {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.user-list {
+  min-width: 220px;
+  max-width: 260px;
+}
+
+.user-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.user-tab {
+  width: 100%;
+  border: none;
+  background: #f3f4f6;
+  color: #1f2937;
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.user-tab:hover {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.user-tab.active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 20px 35px -30px rgba(37, 99, 235, 0.8);
+}
+
+.badge {
+  background: rgba(17, 24, 39, 0.1);
+  color: inherit;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.user-tab.active .badge {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.user-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.user-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.access-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.access-editor-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)) auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.access-editor-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.user-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.loading.small {
+  font-size: 0.95rem;
+  color: #6b7280;
+}
+
+.access-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.access-item {
+  width: 100%;
+  border: 1px solid #dbeafe;
+  background: rgba(239, 246, 255, 0.7);
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.access-list li.selected .access-item {
+  border-color: #2563eb;
+  box-shadow: 0 18px 30px -28px rgba(37, 99, 235, 0.8);
+}
+
+.access-path {
+  font-size: 1.05rem;
+}
+
+.access-password {
+  color: #1d4ed8;
+  font-family: 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .user-management {
+    flex-direction: column;
+  }
+
+  .access-editor-row {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add account management, session authentication, and per-path authorization to the backend API
- introduce reusable FileManager plus new admin and user dashboards with login, password updates, and user management UIs
- expand API helpers and styling to support authentication flows and role-specific layouts

## Testing
- npm run build (frontend)
- node --check backend/src/server.js

------
https://chatgpt.com/codex/tasks/task_e_68ca5c4a37e0832d86ffd365146638cc