### PR TITLE
Add protocols hub to user dashboard

### DIFF
--- a/frontend/src/components/ProtocolHub.jsx
+++ b/frontend/src/components/ProtocolHub.jsx
@@ -1,0 +1,452 @@
+import { useState } from 'react';
+
+const PROTOCOL_DEPARTMENTS = [
+  {
+    id: 'people',
+    label: 'People Ops',
+    icon: '👥',
+    accent: '#2563eb',
+    accentSoft: 'rgba(37, 99, 235, 0.12)',
+    accentStrong: 'rgba(37, 99, 235, 0.55)',
+    border: 'rgba(37, 99, 235, 0.35)',
+    heroGradient: 'linear-gradient(135deg, #2563eb 0%, #1e3a8a 100%)',
+    tags: ['Self-serve', '24h SLA'],
+    preview: ['Leave', 'Shifts', 'Kudos'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '📝',
+        items: [
+          { icon: '📝', label: 'Leave' },
+          { icon: '🕒', label: 'Shifts' },
+          { icon: '🎁', label: 'Perks' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '📋',
+        items: [
+          { icon: '🚀', label: 'Onboard' },
+          { icon: '🔄', label: 'Offboard' },
+          { icon: '🌱', label: 'Growth' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '⚡',
+        items: [
+          { icon: '🛡️', label: 'Conduct' },
+          { icon: '🤝', label: 'Disputes' },
+          { icon: '💰', label: 'Payroll' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'it',
+    label: 'IT Desk',
+    icon: '💻',
+    accent: '#0284c7',
+    accentSoft: 'rgba(2, 132, 199, 0.14)',
+    accentStrong: 'rgba(2, 132, 199, 0.55)',
+    border: 'rgba(2, 132, 199, 0.35)',
+    heroGradient: 'linear-gradient(135deg, #0284c7 0%, #0f172a 100%)',
+    tags: ['Always on', 'Secure'],
+    preview: ['Access', 'Device', 'VPN'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '📥',
+        items: [
+          { icon: '🔑', label: 'Access' },
+          { icon: '💼', label: 'Device' },
+          { icon: '🛰️', label: 'VPN' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '🛠️',
+        items: [
+          { icon: '⚙️', label: 'Deploy' },
+          { icon: '🛡️', label: 'Patch' },
+          { icon: '💾', label: 'Backup' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '🚨',
+        items: [
+          { icon: '🔥', label: 'Incident' },
+          { icon: '📡', label: 'Outage' },
+          { icon: '🕵️‍♂️', label: 'Security' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'finance',
+    label: 'Finance Desk',
+    icon: '💳',
+    accent: '#1d4ed8',
+    accentSoft: 'rgba(29, 78, 216, 0.12)',
+    accentStrong: 'rgba(29, 78, 216, 0.5)',
+    border: 'rgba(29, 78, 216, 0.32)',
+    heroGradient: 'linear-gradient(135deg, #1d4ed8 0%, #312e81 100%)',
+    tags: ['Transparent', 'Tracked'],
+    preview: ['Expense', 'Purchase', 'Budget'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '🧾',
+        items: [
+          { icon: '🧾', label: 'Expense' },
+          { icon: '🛒', label: 'Purchase' },
+          { icon: '💵', label: 'Advance' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '🪙',
+        items: [
+          { icon: '🗓️', label: 'Payroll' },
+          { icon: '📨', label: 'Invoice' },
+          { icon: '📈', label: 'Budget' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '🧭',
+        items: [
+          { icon: '✅', label: 'Approvals' },
+          { icon: '📊', label: 'Limits' },
+          { icon: '🔍', label: 'Audit' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'facilities',
+    label: 'Facilities',
+    icon: '🏢',
+    accent: '#0369a1',
+    accentSoft: 'rgba(3, 105, 161, 0.14)',
+    accentStrong: 'rgba(3, 105, 161, 0.5)',
+    border: 'rgba(3, 105, 161, 0.32)',
+    heroGradient: 'linear-gradient(135deg, #0369a1 0%, #0f172a 100%)',
+    tags: ['Comfort', 'Ready'],
+    preview: ['Seating', 'Repair', 'Transport'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '📬',
+        items: [
+          { icon: '🪑', label: 'Seating' },
+          { icon: '🛠️', label: 'Repair' },
+          { icon: '🚌', label: 'Transport' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '🧹',
+        items: [
+          { icon: '☕', label: 'Pantry' },
+          { icon: '🧴', label: 'Sanitize' },
+          { icon: '📦', label: 'Inventory' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '🚧',
+        items: [
+          { icon: '⚠️', label: 'Safety' },
+          { icon: '🔌', label: 'Power' },
+          { icon: '🤝', label: 'Vendor' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'quality',
+    label: 'Quality & Training',
+    icon: '🎧',
+    accent: '#4338ca',
+    accentSoft: 'rgba(67, 56, 202, 0.14)',
+    accentStrong: 'rgba(67, 56, 202, 0.55)',
+    border: 'rgba(67, 56, 202, 0.32)',
+    heroGradient: 'linear-gradient(135deg, #4338ca 0%, #1e1b4b 100%)',
+    tags: ['Consistent', 'Elevate'],
+    preview: ['QA', 'Coaching', 'Refresh'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '🎯',
+        items: [
+          { icon: '🧪', label: 'QA' },
+          { icon: '🤝', label: 'Calibrate' },
+          { icon: '📜', label: 'Certify' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '📚',
+        items: [
+          { icon: '📖', label: 'Playbook' },
+          { icon: '🎓', label: 'Coaching' },
+          { icon: '🔄', label: 'Refresh' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '📈',
+        items: [
+          { icon: '📉', label: 'Variance' },
+          { icon: '🗣️', label: 'Feedback' },
+          { icon: '⚙️', label: 'Rework' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'workforce',
+    label: 'Workforce',
+    icon: '📅',
+    accent: '#0f766e',
+    accentSoft: 'rgba(15, 118, 110, 0.16)',
+    accentStrong: 'rgba(15, 118, 110, 0.5)',
+    border: 'rgba(15, 118, 110, 0.3)',
+    heroGradient: 'linear-gradient(135deg, #0f766e 0%, #0f172a 100%)',
+    tags: ['Balanced', 'Realtime'],
+    preview: ['Roster', 'Forecast', 'Alerts'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '🗂️',
+        items: [
+          { icon: '📅', label: 'Roster' },
+          { icon: '🕓', label: 'Overtime' },
+          { icon: '🛎️', label: 'Swap' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '📊',
+        items: [
+          { icon: '📈', label: 'Forecast' },
+          { icon: '📉', label: 'Capacity' },
+          { icon: '🧠', label: 'Analytics' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '⏱️',
+        items: [
+          { icon: '📣', label: 'Underfill' },
+          { icon: '🚦', label: 'Overfill' },
+          { icon: '🔔', label: 'Alerts' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'clients',
+    label: 'Client Success',
+    icon: '🤝',
+    accent: '#1e40af',
+    accentSoft: 'rgba(30, 64, 175, 0.14)',
+    accentStrong: 'rgba(30, 64, 175, 0.5)',
+    border: 'rgba(30, 64, 175, 0.32)',
+    heroGradient: 'linear-gradient(135deg, #1e40af 0%, #0b1340 100%)',
+    tags: ['Voice', 'Trusted'],
+    preview: ['Kickoff', 'SLA', 'Updates'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '📨',
+        items: [
+          { icon: '🚀', label: 'Kickoff' },
+          { icon: '⏱️', label: 'SLA' },
+          { icon: '📰', label: 'Updates' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '📣',
+        items: [
+          { icon: '📊', label: 'Insights' },
+          { icon: '🧭', label: 'Cadence' },
+          { icon: '💬', label: 'VOC' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '🛎️',
+        items: [
+          { icon: '⚠️', label: 'Risk' },
+          { icon: '📈', label: 'Escalate' },
+          { icon: '🛡️', label: 'Recovery' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'security',
+    label: 'Security & Compliance',
+    icon: '🛡️',
+    accent: '#312e81',
+    accentSoft: 'rgba(49, 46, 129, 0.16)',
+    accentStrong: 'rgba(49, 46, 129, 0.55)',
+    border: 'rgba(49, 46, 129, 0.3)',
+    heroGradient: 'linear-gradient(135deg, #312e81 0%, #111827 100%)',
+    tags: ['Audit ready', 'Trust'],
+    preview: ['Policy', 'Access', 'Incident'],
+    sections: [
+      {
+        title: 'Requests',
+        icon: '📜',
+        items: [
+          { icon: '📜', label: 'Policy' },
+          { icon: '🔐', label: 'Access' },
+          { icon: '🗄️', label: 'Retention' },
+        ],
+      },
+      {
+        title: 'Routines',
+        icon: '🛠️',
+        items: [
+          { icon: '🧭', label: 'Checks' },
+          { icon: '🧠', label: 'Awareness' },
+          { icon: '🛰️', label: 'Monitoring' },
+        ],
+      },
+      {
+        title: 'Escalate',
+        icon: '🚨',
+        items: [
+          { icon: '🛑', label: 'Incident' },
+          { icon: '📞', label: 'Hotline' },
+          { icon: '⚖️', label: 'Legal' },
+        ],
+      },
+    ],
+  },
+];
+
+const ProtocolHub = () => {
+  const [activeDepartmentId, setActiveDepartmentId] = useState('');
+
+  const activeDepartment = PROTOCOL_DEPARTMENTS.find((dept) => dept.id === activeDepartmentId);
+
+  return (
+    <div className="panel protocols-panel">
+      <div className="panel-header">
+        <h2>Team protocols</h2>
+        <p>Tap a deck to dive into ready-made flows.</p>
+      </div>
+      {!activeDepartment && (
+        <div className="protocols-grid">
+          {PROTOCOL_DEPARTMENTS.map((department) => (
+            <button
+              key={department.id}
+              type="button"
+              className="protocol-card"
+              style={{
+                '--protocol-accent': department.accent,
+                '--protocol-accent-soft': department.accentSoft,
+                '--protocol-accent-strong': department.accentStrong,
+                '--protocol-border': department.border,
+              }}
+              onClick={() => setActiveDepartmentId(department.id)}
+            >
+              <span className="protocol-card-icon" aria-hidden="true">
+                {department.icon}
+              </span>
+              <span className="protocol-card-label">{department.label}</span>
+              <div className="protocol-card-preview">
+                {department.preview.map((item) => (
+                  <span key={item} className="protocol-chip">
+                    {item}
+                  </span>
+                ))}
+              </div>
+              <div className="protocol-card-tags">
+                {department.tags.map((tag) => (
+                  <span key={`${department.id}-${tag}`} className="protocol-card-tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+      {activeDepartment && (
+        <div
+          className="protocol-detail"
+          style={{
+            '--protocol-accent': activeDepartment.accent,
+            '--protocol-accent-soft': activeDepartment.accentSoft,
+            '--protocol-accent-strong': activeDepartment.accentStrong,
+            '--protocol-border': activeDepartment.border,
+          }}
+        >
+          <div
+            className="protocol-detail-hero"
+            style={{ backgroundImage: activeDepartment.heroGradient }}
+          >
+            <div className="protocol-hero-icon" aria-hidden="true">
+              {activeDepartment.icon}
+            </div>
+            <div className="protocol-hero-copy">
+              <span className="protocol-hero-label">{activeDepartment.label}</span>
+              <div className="protocol-hero-tags">
+                {activeDepartment.tags.map((tag) => (
+                  <span key={`${activeDepartment.id}-hero-${tag}`} className="protocol-hero-tag">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              <div className="protocol-hero-quick">
+                {activeDepartment.preview.map((item) => (
+                  <span key={`${activeDepartment.id}-quick-${item}`} className="protocol-chip">
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <button
+              type="button"
+              className="protocol-back"
+              onClick={() => setActiveDepartmentId('')}
+            >
+              ← All decks
+            </button>
+          </div>
+          <div className="protocol-sections">
+            {activeDepartment.sections.map((section) => (
+              <div key={`${activeDepartment.id}-${section.title}`} className="protocol-section">
+                <div className="protocol-section-heading">
+                  <span className="protocol-section-icon" aria-hidden="true">
+                    {section.icon}
+                  </span>
+                  <span className="protocol-section-title">{section.title}</span>
+                </div>
+                <div className="protocol-items">
+                  {section.items.map((item) => (
+                    <button key={`${section.title}-${item.label}`} type="button" className="protocol-item">
+                      <span className="protocol-item-icon" aria-hidden="true">
+                        {item.icon}
+                      </span>
+                      <span className="protocol-item-label">{item.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProtocolHub;

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import FileManager from './FileManager.jsx';
 import AccessList from './AccessList.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
+import ProtocolHub from './ProtocolHub.jsx';
 
 const normalizePath = (input) => {
   if (typeof input !== 'string') {
@@ -47,6 +48,10 @@ const UserDashboard = ({ user, onLogout, onPasswordChange }) => {
           Sign out
         </button>
       </header>
+
+      <section className="dashboard-section">
+        <ProtocolHub />
+      </section>
 
       <section className="dashboard-section">
         <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -920,6 +920,348 @@ body {
   font-size: 0.9rem;
 }
 
+.protocols-panel {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.protocols-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.08), transparent 60%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.protocols-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.protocols-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.protocol-card {
+  position: relative;
+  isolation: isolate;
+  border: 1px solid var(--protocol-border, rgba(37, 99, 235, 0.2));
+  background: linear-gradient(
+    155deg,
+    rgba(255, 255, 255, 0.95) 5%,
+    var(--protocol-accent-soft, rgba(37, 99, 235, 0.1)) 95%
+  );
+  border-radius: 20px;
+  padding: 1.2rem 1.1rem 1.35rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  color: #0f172a;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  box-shadow: 0 26px 60px -48px var(--protocol-accent-strong, rgba(37, 99, 235, 0.45));
+  overflow: hidden;
+}
+
+.protocol-card::after {
+  content: '';
+  position: absolute;
+  top: -70px;
+  right: -60px;
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  background: var(--protocol-accent, rgba(37, 99, 235, 0.45));
+  opacity: 0.35;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  z-index: 0;
+}
+
+.protocol-card:hover::after {
+  transform: scale(1.08);
+  opacity: 0.55;
+}
+
+.protocol-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 36px 80px -55px var(--protocol-accent-strong, rgba(37, 99, 235, 0.55));
+  border-color: var(--protocol-accent, rgba(37, 99, 235, 0.5));
+}
+
+.protocol-card:focus-visible {
+  outline: 2px solid var(--protocol-accent, #2563eb);
+  outline-offset: 3px;
+}
+
+.protocol-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.protocol-card-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.protocol-card-label {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.protocol-card-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.protocol-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: auto;
+}
+
+.protocol-card-tag {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--protocol-accent, #2563eb);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
+}
+
+.protocol-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--protocol-accent, #2563eb);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.18);
+}
+
+.protocol-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.protocol-detail-hero {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  border-radius: 22px;
+  padding: 1.5rem;
+  color: #f8fafc;
+  background-image: var(--protocol-hero-gradient, linear-gradient(135deg, #2563eb 0%, #1e3a8a 100%));
+  box-shadow: 0 35px 90px -55px rgba(15, 23, 42, 0.7);
+  overflow: hidden;
+}
+
+.protocol-detail-hero::after {
+  content: '';
+  position: absolute;
+  bottom: -80px;
+  right: -60px;
+  width: 220px;
+  height: 220px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  opacity: 0.4;
+  z-index: 0;
+}
+
+.protocol-hero-icon,
+.protocol-hero-copy,
+.protocol-back {
+  position: relative;
+  z-index: 1;
+}
+
+.protocol-hero-icon {
+  width: 72px;
+  height: 72px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.4rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+}
+
+.protocol-hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  flex: 1;
+}
+
+.protocol-hero-label {
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.protocol-hero-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.protocol-hero-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(255, 255, 255, 0.25);
+  color: #f8fafc;
+}
+
+.protocol-hero-quick {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.protocol-detail-hero .protocol-chip {
+  background: rgba(255, 255, 255, 0.2);
+  color: #f8fafc;
+  box-shadow: none;
+}
+
+.protocol-back {
+  border: none;
+  background: rgba(255, 255, 255, 0.22);
+  color: #f8fafc;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.protocol-back:hover {
+  background: rgba(255, 255, 255, 0.32);
+  transform: translateY(-1px);
+}
+
+.protocol-back:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
+.protocol-sections {
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.protocol-section {
+  background: linear-gradient(
+    165deg,
+    rgba(255, 255, 255, 0.96) 0%,
+    var(--protocol-accent-soft, rgba(37, 99, 235, 0.08)) 100%
+  );
+  border-radius: 20px;
+  padding: 1.1rem 1.15rem 1.25rem;
+  border: 1px solid var(--protocol-border, rgba(37, 99, 235, 0.18));
+  box-shadow: 0 25px 55px -48px var(--protocol-accent-strong, rgba(37, 99, 235, 0.5));
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.protocol-section-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.protocol-section-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--protocol-accent, #2563eb);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
+}
+
+.protocol-section-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.protocol-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.protocol-item {
+  border: none;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--protocol-accent, #2563eb);
+  border-radius: 12px;
+  padding: 0.45rem 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.protocol-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px -24px var(--protocol-accent-strong, rgba(37, 99, 235, 0.5));
+}
+
+.protocol-item:focus-visible {
+  outline: 2px solid var(--protocol-accent, #2563eb);
+  outline-offset: 2px;
+}
+
+.protocol-item-icon {
+  font-size: 1rem;
+}
+
+.protocol-item-label {
+  font-size: 0.85rem;
+}
+
 @media (max-width: 900px) {
   .dashboard-header {
     flex-direction: column;
@@ -932,5 +1274,23 @@ body {
 
   .access-editor-row {
     grid-template-columns: 1fr;
+  }
+
+  .protocol-detail-hero {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .protocols-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .protocol-sections {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .protocol-back {
+    align-self: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add an interactive ProtocolHub card deck for departmental procedures on the user dashboard
- surface the protocols hub ahead of existing access controls so users can jump into departmental flows
- craft tailored styling for the new protocol cards, hero view, and section chips to match the existing theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb8998361c832da16b592ce23581c6