### PR TITLE
Implement chat system and two-column dashboards

### DIFF
--- a/backend/chat.json
+++ b/backend/chat.json
@@ -1,0 +1,11 @@
+{
+  "conversations": {
+    "group:public": {
+      "id": "group:public",
+      "type": "group",
+      "name": "Public Lobby",
+      "description": "Chat with everyone in the workspace.",
+      "messages": []
+    }
+  }
+}

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,6 +1,8 @@
 import FileManager from './FileManager.jsx';
 import UserManagementPanel from './UserManagementPanel.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
+import ProtocolHub from './ProtocolHub.jsx';
+import ChatPanel from './chat/ChatPanel.jsx';
 
 const AdminDashboard = ({ user, onLogout, onPasswordChange, onRefreshUser }) => (
   <div className="dashboard">
@@ -14,20 +16,34 @@ const AdminDashboard = ({ user, onLogout, onPasswordChange, onRefreshUser }) => 
       </button>
     </header>
 
-    <section className="dashboard-section">
-      <FileManager
-        title="NAS file explorer"
-        subtitle="Manage all files and folders stored on the NAS."
-      />
-    </section>
+    <div className="dashboard-grid">
+      <div className="dashboard-column storage-column">
+        <section className="dashboard-section">
+          <FileManager
+            title="NAS file explorer"
+            subtitle="Manage all files and folders stored on the NAS."
+          />
+        </section>
 
-    <section className="dashboard-section">
-      <UserManagementPanel onUsersChanged={onRefreshUser} />
-    </section>
+        <section className="dashboard-section">
+          <UserManagementPanel onUsersChanged={onRefreshUser} />
+        </section>
+      </div>
 
-    <section className="dashboard-section">
-      <ChangePasswordForm title="Update your administrator password" onSubmit={onPasswordChange} />
-    </section>
+      <div className="dashboard-column insights-column">
+        <section className="dashboard-section">
+          <ProtocolHub />
+        </section>
+
+        <section className="dashboard-section">
+          <ChatPanel currentUser={user} />
+        </section>
+
+        <section className="dashboard-section">
+          <ChangePasswordForm title="Update your administrator password" onSubmit={onPasswordChange} />
+        </section>
+      </div>
+    </div>
   </div>
 );
 

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -3,6 +3,7 @@ import FileManager from './FileManager.jsx';
 import AccessList from './AccessList.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
+import ChatPanel from './chat/ChatPanel.jsx';
 
 const normalizePath = (input) => {
   if (typeof input !== 'string') {
@@ -49,30 +50,40 @@ const UserDashboard = ({ user, onLogout, onPasswordChange }) => {
         </button>
       </header>
 
-      <section className="dashboard-section">
-        <ProtocolHub />
-      </section>
+      <div className="dashboard-grid">
+        <div className="dashboard-column storage-column">
+          <section className="dashboard-section">
+            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
+          </section>
 
-      <section className="dashboard-section">
-        <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
-      </section>
+          {hasAssignedAccess && (
+            <section className="dashboard-section">
+              <FileManager
+                title="Your file explorer"
+                subtitle="All changes you make stay within your assigned folders."
+                initialPath={selectedPath}
+                rootPath={selectedPath}
+                allowLockToggle={false}
+                passwordLookup={passwordLookup}
+              />
+            </section>
+          )}
+        </div>
 
-      {hasAssignedAccess && (
-        <section className="dashboard-section">
-          <FileManager
-            title="Your file explorer"
-            subtitle="All changes you make stay within your assigned folders."
-            initialPath={selectedPath}
-            rootPath={selectedPath}
-            allowLockToggle={false}
-            passwordLookup={passwordLookup}
-          />
-        </section>
-      )}
+        <div className="dashboard-column insights-column">
+          <section className="dashboard-section">
+            <ProtocolHub />
+          </section>
 
-      <section className="dashboard-section">
-        <ChangePasswordForm title="Update your password" onSubmit={onPasswordChange} />
-      </section>
+          <section className="dashboard-section">
+            <ChatPanel currentUser={user} />
+          </section>
+
+          <section className="dashboard-section">
+            <ChangePasswordForm title="Update your password" onSubmit={onPasswordChange} />
+          </section>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ChatSidebar from './ChatSidebar.jsx';
+import ChatWindow from './ChatWindow.jsx';
+import { fetchChatMessages, fetchChatRoster, sendChatMessage } from '../../services/api.js';
+
+const ChatPanel = ({ currentUser }) => {
+  const [roster, setRoster] = useState({ users: [], groups: [] });
+  const [activeTarget, setActiveTarget] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [conversation, setConversation] = useState(null);
+  const [isLoadingRoster, setIsLoadingRoster] = useState(true);
+  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState('');
+  const currentUsername = currentUser?.username || '';
+
+  const buildTargetKey = (target) => {
+    if (!target) {
+      return '';
+    }
+    return target.type === 'dm' ? `dm:${target.username}` : `group:${target.id}`;
+  };
+
+  const activeKeyRef = useRef('');
+
+  useEffect(() => {
+    activeKeyRef.current = buildTargetKey(activeTarget);
+  }, [activeTarget]);
+
+  const loadRoster = useCallback(async () => {
+    setIsLoadingRoster(true);
+    try {
+      const data = await fetchChatRoster();
+      setRoster({
+        users: Array.isArray(data.users) ? data.users : [],
+        groups: Array.isArray(data.groups) ? data.groups : [],
+      });
+    } catch (err) {
+      setError(err.message || 'Unable to load chat roster');
+    } finally {
+      setIsLoadingRoster(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadRoster();
+  }, [loadRoster]);
+
+  const handleSelect = useCallback(
+    (target) => {
+      setError('');
+      setMessages([]);
+      if (target) {
+        const participants =
+          target.type === 'dm'
+            ? [currentUsername, target.username].filter(Boolean)
+            : [];
+        setConversation({
+          id: '',
+          type: target.type,
+          name: target.name || target.username || '',
+          description: target.description,
+          participants,
+        });
+      } else {
+        setConversation(null);
+      }
+      setActiveTarget(target);
+    },
+    [currentUsername]
+  );
+
+  useEffect(() => {
+    if (activeTarget) {
+      return;
+    }
+    if (roster.groups.length > 0) {
+      handleSelect({
+        type: 'group',
+        id: roster.groups[0].id,
+        name: roster.groups[0].name,
+        description: roster.groups[0].description,
+      });
+      return;
+    }
+    if (roster.users.length > 0) {
+      handleSelect({ type: 'dm', username: roster.users[0].username });
+    }
+  }, [activeTarget, handleSelect, roster.groups, roster.users]);
+
+  const loadMessages = useCallback(
+    async (target, { silent = false } = {}) => {
+      if (!target) {
+        setMessages([]);
+        setConversation(null);
+        return false;
+      }
+      const targetKey = buildTargetKey(target);
+      if (!silent) {
+        setIsLoadingMessages(true);
+        setError('');
+      }
+      try {
+        const params = target.type === 'dm'
+          ? { username: target.username }
+          : { conversationId: target.id };
+        const response = await fetchChatMessages(params);
+        if (activeKeyRef.current !== targetKey) {
+          return false;
+        }
+        setMessages(Array.isArray(response.messages) ? response.messages : []);
+        setConversation({
+          id: response.conversationId,
+          type: response.type,
+          name: response.name || target.name || target.username || '',
+          description: response.description,
+          participants: Array.isArray(response.participants) ? response.participants : [],
+        });
+        return true;
+      } catch (err) {
+        setError(err.message || 'Unable to load messages');
+        return false;
+      } finally {
+        if (!silent) {
+          setIsLoadingMessages(false);
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!activeTarget) {
+      return;
+    }
+    let cancelled = false;
+
+    const fetchNow = async () => {
+      const success = await loadMessages(activeTarget);
+      if (!success && !cancelled) {
+        setConversation(null);
+      }
+    };
+
+    fetchNow();
+    const interval = setInterval(() => {
+      loadMessages(activeTarget, { silent: true });
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [activeTarget, loadMessages]);
+
+  const handleSendMessage = useCallback(
+    async (content) => {
+      if (!activeTarget) {
+        throw new Error('No conversation selected');
+      }
+      setError('');
+      setIsSending(true);
+      try {
+        if (activeTarget.type === 'dm') {
+          await sendChatMessage({ username: activeTarget.username, content });
+        } else {
+          await sendChatMessage({ conversationId: activeTarget.id, content });
+        }
+        const refreshed = await loadMessages(activeTarget, { silent: true });
+        if (!refreshed) {
+          throw new Error('Unable to refresh conversation');
+        }
+      } catch (err) {
+        setError(err.message || 'Unable to send message');
+        throw err;
+      } finally {
+        setIsSending(false);
+      }
+    },
+    [activeTarget, loadMessages]
+  );
+
+  const sidebarUsers = useMemo(() => roster.users, [roster.users]);
+  const sidebarGroups = useMemo(() => roster.groups, [roster.groups]);
+
+  return (
+    <div className="panel chat-panel">
+      <div className="panel-header">
+        <h2>Team chat</h2>
+        <p>Send direct messages or join the public lobby.</p>
+      </div>
+      <div className="panel-content chat-body">
+        <ChatSidebar
+          groups={sidebarGroups}
+          users={sidebarUsers}
+          activeTarget={activeTarget}
+          onSelect={handleSelect}
+          isLoading={isLoadingRoster}
+        />
+        <ChatWindow
+          currentUser={currentUser}
+          conversation={conversation}
+          messages={messages}
+          isLoading={isLoadingMessages}
+          isSending={isSending}
+          onSend={handleSendMessage}
+          error={error}
+          hasSelection={Boolean(activeTarget)}
+          rosterLoading={isLoadingRoster}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ChatPanel;

--- a/frontend/src/components/chat/ChatSidebar.jsx
+++ b/frontend/src/components/chat/ChatSidebar.jsx
@@ -1,0 +1,71 @@
+const ChatSidebar = ({ groups = [], users = [], activeTarget, onSelect, isLoading }) => {
+  const hasGroups = Array.isArray(groups) && groups.length > 0;
+  const hasUsers = Array.isArray(users) && users.length > 0;
+
+  const buildClassName = (base, isActive) => {
+    return isActive ? `${base} is-active` : base;
+  };
+
+  return (
+    <aside className="chat-sidebar">
+      <section className="chat-sidebar-section">
+        <p className="chat-sidebar-title">Groups</p>
+        {!hasGroups && !isLoading && <p className="chat-sidebar-empty">No groups available.</p>}
+        {isLoading && <p className="chat-sidebar-empty">Loading…</p>}
+        {hasGroups && (
+          <ul className="chat-sidebar-list">
+            {groups.map((group) => {
+              const isActive = activeTarget?.type === 'group' && activeTarget?.id === group.id;
+              return (
+                <li key={group.id}>
+                  <button
+                    type="button"
+                    className={buildClassName('chat-option', isActive)}
+                    onClick={() =>
+                      onSelect?.({
+                        type: 'group',
+                        id: group.id,
+                        name: group.name,
+                        description: group.description,
+                      })
+                    }
+                    title={group.description}
+                  >
+                    <span className="chat-option-title">{group.name}</span>
+                    {group.description && <span className="chat-option-subtitle">{group.description}</span>}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section className="chat-sidebar-section">
+        <p className="chat-sidebar-title">Direct messages</p>
+        {!hasUsers && !isLoading && <p className="chat-sidebar-empty">No teammates yet.</p>}
+        {hasUsers && (
+          <ul className="chat-sidebar-list">
+            {users.map((user) => {
+              const isActive = activeTarget?.type === 'dm' && activeTarget?.username === user.username;
+              return (
+                <li key={user.username}>
+                  <button
+                    type="button"
+                    className={buildClassName('chat-option', isActive)}
+                    onClick={() => onSelect?.({ type: 'dm', username: user.username })}
+                  >
+                    <span className="chat-option-title">{user.username}</span>
+                    <span className="chat-option-subtitle">{user.role === 'admin' ? 'Admin' : 'User'}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </aside>
+  );
+};
+
+export default ChatSidebar;

--- a/frontend/src/components/chat/ChatWindow.jsx
+++ b/frontend/src/components/chat/ChatWindow.jsx
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const formatTimestamp = (timestamp) => {
+  if (!timestamp) {
+    return '';
+  }
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+};
+
+const ChatWindow = ({
+  currentUser,
+  conversation,
+  messages,
+  isLoading,
+  isSending,
+  onSend,
+  error,
+  hasSelection,
+  rosterLoading,
+}) => {
+  const [draft, setDraft] = useState('');
+  const listRef = useRef(null);
+  const currentUsername = currentUser?.username;
+
+  const conversationTitle = useMemo(() => {
+    if (!conversation) {
+      return 'Select a conversation';
+    }
+    if (conversation.name) {
+      return conversation.name;
+    }
+    if (conversation.type === 'dm' && Array.isArray(conversation.participants)) {
+      const other = conversation.participants.find((name) => name !== currentUsername);
+      return other || 'Direct message';
+    }
+    return 'Conversation';
+  }, [conversation, currentUsername]);
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [messages, isLoading, conversation?.id]);
+
+  useEffect(() => {
+    setDraft('');
+  }, [conversation?.id]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmed = draft.trim();
+    if (!trimmed || isSending) {
+      return;
+    }
+    try {
+      await onSend?.(trimmed);
+      setDraft('');
+    } catch (err) {
+      // Keep the draft so the user can retry.
+    }
+  };
+
+  const showComposer = Boolean(hasSelection && !rosterLoading);
+
+  return (
+    <div className="chat-window">
+      <div className="chat-window-header">
+        <div>
+          <h3>{conversationTitle}</h3>
+          {conversation?.type === 'group' && conversation?.description && (
+            <p className="chat-window-subtitle">{conversation.description}</p>
+          )}
+          {conversation?.type === 'dm' && conversation?.participants && (
+            <p className="chat-window-subtitle">Private conversation</p>
+          )}
+        </div>
+      </div>
+
+      <div className="chat-message-board" ref={listRef}>
+        {isLoading && <div className="chat-loading">Loading messages…</div>}
+        {!isLoading && messages.length === 0 && hasSelection && (
+          <div className="chat-empty-state">Start the conversation with your first message.</div>
+        )}
+        {!isLoading && !hasSelection && !rosterLoading && (
+          <div className="chat-empty-state">Choose a conversation to start chatting.</div>
+        )}
+        {!isLoading && !hasSelection && rosterLoading && (
+          <div className="chat-empty-state">Preparing your chat roster…</div>
+        )}
+        {!isLoading &&
+          messages.map((message) => {
+            const isOwnMessage = message.sender === currentUsername;
+            return (
+              <div
+                key={message.id}
+                className={`chat-message ${isOwnMessage ? 'outgoing' : 'incoming'}`}
+              >
+                <div className="chat-meta">
+                  <span className="chat-meta-sender">{isOwnMessage ? 'You' : message.sender}</span>
+                  {message.timestamp && (
+                    <span className="chat-meta-time">{formatTimestamp(message.timestamp)}</span>
+                  )}
+                </div>
+                <div className="chat-bubble">{message.content}</div>
+              </div>
+            );
+          })}
+      </div>
+
+      {error && <div className="chat-error" role="alert">{error}</div>}
+
+      {showComposer && (
+        <form className="chat-composer" onSubmit={handleSubmit}>
+          <textarea
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder={conversation ? 'Type your message…' : 'Select a conversation to chat'}
+            disabled={!conversation || isSending}
+            rows={2}
+          />
+          <button type="submit" className="button chat-send-button" disabled={!draft.trim() || isSending}>
+            {isSending ? 'Sending…' : 'Send'}
+          </button>
+        </form>
+      )}
+
+      {!showComposer && !rosterLoading && (
+        <div className="chat-composer-placeholder">Invite teammates to start a conversation.</div>
+      )}
+    </div>
+  );
+};
+
+export default ChatWindow;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -218,3 +218,36 @@ export function deleteUser(username) {
     method: 'DELETE',
   });
 }
+
+export function fetchChatRoster() {
+  return request('/chat/roster');
+}
+
+export function fetchChatMessages({ username, conversationId } = {}) {
+  const params = new URLSearchParams();
+  if (username) {
+    params.set('username', username);
+  }
+  if (conversationId) {
+    params.set('conversationId', conversationId);
+  }
+  const query = params.toString();
+  if (!query) {
+    throw new Error('username or conversationId is required to load chat messages');
+  }
+  return request(`/chat/messages?${query}`);
+}
+
+export function sendChatMessage({ username, conversationId, content }) {
+  const body = { content };
+  if (username) {
+    body.username = username;
+  }
+  if (conversationId) {
+    body.conversationId = conversationId;
+  }
+  return request('/chat/messages', {
+    method: 'POST',
+    body,
+  });
+}

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -673,6 +673,25 @@ body {
   gap: 1rem;
 }
 
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2.1fr) minmax(0, 1.2fr);
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.dashboard-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (max-width: 1100px) {
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .muted {
   color: #6b7280;
   margin: 0;
@@ -708,6 +727,237 @@ body {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.chat-panel .panel-header {
+  margin-bottom: 0;
+}
+
+.chat-body {
+  display: grid;
+  grid-template-columns: minmax(0, 230px) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+@media (max-width: 980px) {
+  .chat-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chat-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.08) 0%, rgba(37, 99, 235, 0.04) 100%);
+  border-radius: 16px;
+  padding: 0.9rem;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.08);
+}
+
+.chat-sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-sidebar-title {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.chat-sidebar-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-sidebar-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.chat-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  border: none;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 14px;
+  padding: 0.7rem 0.8rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.chat-option:hover {
+  background: rgba(37, 99, 235, 0.16);
+}
+
+.chat-option.is-active {
+  background: #2563eb;
+  color: #ffffff;
+  box-shadow: 0 22px 40px -28px rgba(37, 99, 235, 0.8);
+}
+
+.chat-option-title {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.chat-option-subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.75rem;
+  color: rgba(31, 41, 55, 0.65);
+}
+
+.chat-option.is-active .chat-option-subtitle {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.chat-window {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chat-window-header h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+}
+
+.chat-window-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.chat-message-board {
+  flex: 1;
+  min-height: 320px;
+  max-height: 460px;
+  overflow-y: auto;
+  background: rgba(248, 250, 252, 0.8);
+  border-radius: 18px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.06);
+}
+
+.chat-loading {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.chat-empty-state {
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.chat-message {
+  max-width: 75%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.chat-message.outgoing {
+  margin-left: auto;
+  align-items: flex-end;
+}
+
+.chat-message.incoming {
+  margin-right: auto;
+  align-items: flex-start;
+}
+
+.chat-meta {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.chat-bubble {
+  padding: 0.7rem 0.85rem;
+  border-radius: 16px;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  box-shadow: 0 18px 38px -32px rgba(15, 23, 42, 0.8);
+  word-break: break-word;
+}
+
+.chat-message.outgoing .chat-bubble {
+  background: #2563eb;
+  color: #ffffff;
+  border-bottom-right-radius: 6px;
+}
+
+.chat-message.incoming .chat-bubble {
+  background: #ffffff;
+  color: #111827;
+  border-bottom-left-radius: 6px;
+}
+
+.chat-error {
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.chat-composer {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  background: rgba(37, 99, 235, 0.08);
+  padding: 0.6rem;
+  border-radius: 16px;
+}
+
+.chat-composer textarea {
+  flex: 1;
+  border: none;
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  resize: none;
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: #111827;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.12);
+}
+
+.chat-composer textarea:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgba(37, 99, 235, 0.35);
+}
+
+.chat-composer textarea:disabled {
+  background: rgba(255, 255, 255, 0.6);
+  color: #9ca3af;
+}
+
+.chat-send-button {
+  flex-shrink: 0;
+  min-width: 96px;
+}
+
+.chat-composer-placeholder {
+  font-size: 0.85rem;
+  color: #6b7280;
 }
 
 .panel-actions {


### PR DESCRIPTION
## Summary
- add persistent chat storage and API endpoints for roster, fetching messages, and sending messages
- split user and admin dashboards into storage and insights columns with ProtocolHub and the new chat panel
- implement chat UI components, related API helpers, and styling for the conversation experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbac165604832dbb00b104bc14ad50