### PR TITLE
Refine admin UI and add dialog-based interactions

### DIFF
--- a/backend/src/services/profileService.js
+++ b/backend/src/services/profileService.js
@@ -1,0 +1,101 @@
+const path = require('path');
+const fs = require('fs/promises');
+const {
+  loadAccounts,
+  saveAccounts,
+  toPublicUser,
+} = require('../stores/accountStore');
+
+const CHAT_FILE = path.join(__dirname, '..', '..', 'chat.json');
+const NOTICES_FILE = path.join(__dirname, '..', '..', 'notices.json');
+const PROCUREMENT_FILE = path.join(__dirname, '..', '..', 'procurement.json');
+
+async function loadJson(filePath, fallback) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code === 'ENOENT' && typeof fallback !== 'undefined') {
+      return fallback;
+    }
+    throw error;
+  }
+}
+
+async function saveJson(filePath, data) {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+}
+
+function replaceUsernameDeep(value, oldUsername, newUsername) {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const result = replaceUsernameDeep(item, oldUsername, newUsername);
+      if (result.changed) {
+        changed = true;
+      }
+      return result.value;
+    });
+    return { changed, value: next };
+  }
+  if (value && typeof value === 'object') {
+    let changed = false;
+    const next = {};
+    Object.entries(value).forEach(([key, val]) => {
+      const result = replaceUsernameDeep(val, oldUsername, newUsername);
+      if (result.changed) {
+        changed = true;
+      }
+      next[key] = result.value;
+    });
+    return { changed, value: next };
+  }
+  if (typeof value === 'string' && value === oldUsername) {
+    return { changed: true, value: newUsername };
+  }
+  return { changed: false, value };
+}
+
+async function replaceInStore(filePath, fallback, oldUsername, newUsername) {
+  const data = await loadJson(filePath, fallback);
+  const { changed, value } = replaceUsernameDeep(data, oldUsername, newUsername);
+  if (changed) {
+    await saveJson(filePath, value);
+  }
+}
+
+async function renameAccountUsername(oldUsername, newUsername) {
+  const accounts = await loadAccounts();
+  const account = accounts.users[oldUsername];
+  if (!account) {
+    const error = new Error('Account not found');
+    error.status = 404;
+    throw error;
+  }
+  if (accounts.users[newUsername]) {
+    const error = new Error('A user with this username already exists');
+    error.status = 409;
+    throw error;
+  }
+
+  delete accounts.users[oldUsername];
+  account.username = newUsername;
+  account.updatedAt = new Date().toISOString();
+  accounts.users[newUsername] = account;
+  await saveAccounts(accounts);
+
+  await Promise.all([
+    replaceInStore(CHAT_FILE, { conversations: {} }, oldUsername, newUsername),
+    replaceInStore(NOTICES_FILE, { notices: [] }, oldUsername, newUsername),
+    replaceInStore(PROCUREMENT_FILE, { nextSequence: 1, requests: [] }, oldUsername, newUsername),
+  ]);
+
+  return {
+    account,
+    publicUser: toPublicUser(account),
+  };
+}
+
+module.exports = {
+  renameAccountUsername,
+};

--- a/backend/src/stores/accountStore.js
+++ b/backend/src/stores/accountStore.js
@@ -1,0 +1,141 @@
+const path = require('path');
+const fs = require('fs/promises');
+const bcrypt = require('bcryptjs');
+
+const ACCOUNTS_FILE = path.join(__dirname, '..', '..', 'accounts.json');
+
+function normalizeRelative(input = '') {
+  const safeInput = String(input).replace(/\\/g, '/').trim();
+  const segments = safeInput.split('/');
+  const stack = [];
+
+  segments.forEach((segment) => {
+    if (!segment || segment === '.') {
+      return;
+    }
+    if (segment === '..') {
+      if (stack.length) {
+        stack.pop();
+      }
+      return;
+    }
+    stack.push(segment);
+  });
+
+  return stack.join('/');
+}
+
+async function loadAccounts() {
+  try {
+    const data = await fs.readFile(ACCOUNTS_FILE, 'utf8');
+    const parsed = JSON.parse(data);
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.users !== 'object') {
+      throw new Error('Invalid accounts file');
+    }
+    return parsed;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      const empty = { users: {} };
+      await fs.writeFile(ACCOUNTS_FILE, JSON.stringify(empty, null, 2));
+      return empty;
+    }
+    throw error;
+  }
+}
+
+async function saveAccounts(accounts) {
+  const payload = {
+    users: accounts.users || {},
+  };
+  await fs.writeFile(ACCOUNTS_FILE, JSON.stringify(payload, null, 2));
+}
+
+async function ensureAccountsInitialized() {
+  const accounts = await loadAccounts();
+  if (!accounts.users || typeof accounts.users !== 'object') {
+    accounts.users = {};
+  }
+  if (!accounts.users.Admin) {
+    const now = new Date().toISOString();
+    const passwordHash = await bcrypt.hash('HTS', 10);
+    accounts.users.Admin = {
+      username: 'Admin',
+      role: 'admin',
+      passwordHash,
+      access: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    await saveAccounts(accounts);
+  }
+
+  const seededUsers = [
+    { username: 'Finance', role: 'finance' },
+    { username: 'Procurement', role: 'procurement' },
+    { username: 'DepartmentHead', role: 'dept-head' },
+  ];
+
+  let changed = false;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const seed of seededUsers) {
+    if (!accounts.users[seed.username]) {
+      const now = new Date().toISOString();
+      const passwordHash = await bcrypt.hash('HTS', 10);
+      accounts.users[seed.username] = {
+        username: seed.username,
+        role: seed.role,
+        passwordHash,
+        access: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    await saveAccounts(accounts);
+  }
+}
+
+function sanitizeUsername(input) {
+  if (typeof input !== 'string') {
+    return '';
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+  const safe = trimmed.replace(/[^A-Za-z0-9_.-]/g, '');
+  return safe;
+}
+
+function getAccessList(account) {
+  if (!account || !Array.isArray(account.access)) {
+    return [];
+  }
+  return account.access.map((entry) => ({
+    path: normalizeRelative(entry.path || ''),
+    password: String(entry.password || ''),
+  }));
+}
+
+function toPublicUser(account) {
+  return {
+    username: account.username,
+    role: account.role,
+    access: getAccessList(account),
+    createdAt: account.createdAt,
+    updatedAt: account.updatedAt,
+  };
+}
+
+module.exports = {
+  ACCOUNTS_FILE,
+  loadAccounts,
+  saveAccounts,
+  ensureAccountsInitialized,
+  sanitizeUsername,
+  getAccessList,
+  toPublicUser,
+};

--- a/frontend-next/src/components/AdminDashboard.jsx
+++ b/frontend-next/src/components/AdminDashboard.jsx
@@ -1,58 +1,48 @@
+import { useState } from 'react';
 import FileManager from './FileManager.jsx';
 import UserManagementPanel from './UserManagementPanel.jsx';
-import ChangePasswordForm from './ChangePasswordForm.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
+import AdminHero from './admin/AdminHero.jsx';
+import AdminControlPanel from './admin/AdminControlPanel.jsx';
+import AdminSettingsOverlay from './admin/AdminSettingsOverlay.jsx';
 
-const AdminDashboard = ({ user, onPasswordChange, onRefreshUser }) => (
-  <div className="flex flex-col gap-7 text-slate-900">
-    <header className="glass-panel relative flex flex-col gap-4 overflow-hidden p-5 sm:flex-row sm:items-center sm:justify-between">
-      <div className="pointer-events-none chroma-grid" />
-      <div className="relative z-10 space-y-2">
-        <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">
-          Admin Control
-        </div>
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight sm:text-[2rem]">
-            Welcome, {user.username}
-          </h1>
-          <p className="text-sm font-medium text-slate-600 sm:text-base">
-            You have administrator access to the HTS NAS.
-          </p>
-        </div>
-      </div>
-      <span className="relative z-10 glass-chip text-xs tracking-[0.35em] text-blue-700">Administrator</span>
-    </header>
+const AdminDashboard = ({ user, onPasswordChange, onRefreshUser }) => {
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.55fr)_minmax(0,1fr)]">
-      <div className="flex flex-col gap-6">
-        <section>
-          <FileManager
-            title="NAS file explorer"
-            subtitle="Manage all files and folders stored on the NAS."
-          />
-        </section>
+  return (
+    <div className="flex flex-col gap-7 text-slate-900">
+      <AdminHero user={user} onOpenSettings={() => setSettingsOpen(true)} />
 
-        <section>
-          <UserManagementPanel onUsersChanged={onRefreshUser} />
-        </section>
-      </div>
+      <AdminControlPanel
+        primary={[
+          <section key="file-manager">
+            <FileManager title="NAS file explorer" subtitle="Manage all files and folders stored on the NAS." />
+          </section>,
+          <section key="user-management">
+            <UserManagementPanel onUsersChanged={onRefreshUser} />
+          </section>,
+        ]}
+        secondary={[
+          <section key="protocols">
+            <ProtocolHub />
+          </section>,
+          <section key="notices">
+            <NoticeBoard currentUser={user} />
+          </section>,
+        ]}
+      />
 
-      <div className="flex flex-col gap-6">
-        <section>
-          <ProtocolHub />
-        </section>
-
-        <section>
-          <NoticeBoard currentUser={user} />
-        </section>
-
-        <section>
-          <ChangePasswordForm title="Update your administrator password" onSubmit={onPasswordChange} />
-        </section>
-      </div>
+      {settingsOpen ? (
+        <AdminSettingsOverlay
+          user={user}
+          onClose={() => setSettingsOpen(false)}
+          onProfileUpdated={onRefreshUser}
+          onPasswordChange={onPasswordChange}
+        />
+      ) : null}
     </div>
-  </div>
-);
+  );
+};
 
 export default AdminDashboard;

--- a/frontend-next/src/components/NoticeBoard.jsx
+++ b/frontend-next/src/components/NoticeBoard.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchNotices, createNotice } from '../services/api.js';
 
 const formatTimestamp = (timestamp) => {
@@ -11,6 +11,82 @@ const formatTimestamp = (timestamp) => {
   }
   return date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
 };
+
+const NoticeBadge = ({ label }) => (
+  <span className="rounded-full border border-white/40 bg-white/45 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-blue-600">
+    {label}
+  </span>
+);
+
+const NoticeItem = ({ notice, isOwn }) => (
+  <li
+    className={`relative rounded-2xl border px-4 py-3 shadow-sm transition ${
+      isOwn
+        ? 'border-emerald-300/70 bg-gradient-to-br from-emerald-400/25 via-emerald-400/15 to-blue-400/15 text-emerald-800 shadow-[0_18px_45px_-32px_rgba(16,185,129,0.7)]'
+        : 'border-white/35 bg-white/60 text-slate-700 shadow-[0_18px_45px_-32px_rgba(15,23,42,0.25)]'
+    }`}
+  >
+    <div className="flex items-baseline justify-between gap-3 text-xs font-semibold uppercase tracking-wide text-slate-400">
+      <div className="flex items-baseline gap-2">
+        <span className="text-slate-600">{isOwn ? 'You' : notice.author}</span>
+        {notice.timestamp ? (
+          <time dateTime={notice.timestamp} className="text-slate-400">
+            {formatTimestamp(notice.timestamp)}
+          </time>
+        ) : null}
+      </div>
+      <span className="rounded-full border border-white/40 bg-white/30 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-blue-500">
+        Notice
+      </span>
+    </div>
+    <p className="mt-2 whitespace-pre-wrap text-sm font-medium text-slate-700">{notice.message}</p>
+  </li>
+);
+
+const NoticeTimeline = ({ notices, username }) => {
+  if (!notices.length) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-2xl border border-white/35 bg-white/60 p-6 text-center text-sm font-semibold text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+        <span className="text-xs uppercase tracking-[0.35em] text-blue-500">No notices</span>
+        <p className="max-w-sm text-sm font-medium text-slate-600">
+          Be the first to share an update with your team.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex max-h-72 flex-col gap-3 overflow-y-auto pr-1 text-sm">
+      {notices.map((notice) => (
+        <NoticeItem key={notice.id} notice={notice} isOwn={notice.author === username} />
+      ))}
+    </ul>
+  );
+};
+
+const NoticeComposer = ({ draft, onChange, onSubmit, disabled }) => (
+  <form className="relative z-10 flex flex-col gap-3" onSubmit={onSubmit}>
+    <textarea
+      value={draft}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder="Post a new notice for the team"
+      rows={3}
+      maxLength={2000}
+      disabled={disabled}
+      className="w-full rounded-2xl border border-white/35 bg-white/45 px-4 py-3 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60 disabled:cursor-not-allowed disabled:opacity-60"
+    />
+    <div className="flex flex-wrap items-center justify-between gap-3 text-xs font-semibold text-slate-400 sm:text-sm">
+      <span>{draft.length}/2000</span>
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={disabled || !draft.trim()}
+      >
+        {disabled ? 'Posting…' : 'Post notice'}
+      </button>
+    </div>
+  </form>
+);
 
 const NoticeBoard = ({ currentUser }) => {
   const username = currentUser?.username || '';
@@ -96,97 +172,62 @@ const NoticeBoard = ({ currentUser }) => {
     [draft, isPosting, loadNotices]
   );
 
-  const isSubmittingDisabled = !draft.trim() || isPosting;
+  const stats = useMemo(() => {
+    const latest = notices[0];
+    return {
+      total: notices.length,
+      latestAt: latest?.timestamp ? formatTimestamp(latest.timestamp) : null,
+    };
+  }, [notices]);
 
   return (
-    <div className="glass-panel relative flex h-full flex-col gap-6 overflow-hidden p-5">
+    <div className="glass-panel relative flex h-full flex-col gap-6 overflow-hidden p-6">
       <div className="pointer-events-none chroma-grid" />
-      <div
-        className="orb-glow"
-        style={{
-          top: '-24%',
-          right: '-12%',
-          width: '280px',
-          height: '280px',
-          background: 'radial-gradient(circle, rgba(56,189,248,0.45), transparent 62%)',
-        }}
-      />
-      <div className="relative z-10 space-y-1">
-        <h2 className="text-lg font-bold text-slate-900 sm:text-xl">Team notices</h2>
-        <p className="text-sm font-medium text-slate-600">Share quick updates that everyone can see.</p>
-      </div>
-      {error && (
-        <div
-          className="relative z-10 rounded-2xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]"
-          role="alert"
-        >
-          {error}
+      <div className="relative z-10 flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-bold text-slate-900 sm:text-xl">Team notices</h2>
+            <p className="text-sm font-medium text-slate-600">
+              Share quick updates that everyone can see. The board refreshes automatically every 10 seconds.
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-2 text-right text-xs font-semibold text-slate-500">
+            <div className="flex items-center gap-2">
+              <NoticeBadge label={`Total ${stats.total}`} />
+              <button
+                type="button"
+                onClick={() => loadNotices()}
+                className="inline-flex items-center gap-2 rounded-full border border-white/45 bg-white/40 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-blue-600 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.3)] transition hover:bg-white/55 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              >
+                Refresh
+              </button>
+            </div>
+            {stats.latestAt ? (
+              <span className="text-[10px] uppercase tracking-[0.35em] text-slate-400">
+                Latest: {stats.latestAt}
+              </span>
+            ) : null}
+          </div>
         </div>
-      )}
-      <div
-        className="relative z-10 flex flex-1 flex-col gap-4 rounded-2xl border border-white/25 bg-white/30 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]"
-        aria-live="polite"
-      >
+        {error ? (
+          <div
+            className="relative z-10 rounded-2xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]"
+            role="alert"
+          >
+            {error}
+          </div>
+        ) : null}
+      </div>
+      <div className="relative z-10 flex flex-1 flex-col gap-4 rounded-2xl border border-white/25 bg-white/30 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
         {loading ? (
           <div className="flex flex-1 items-center justify-center text-sm font-semibold text-slate-500">
             Loading notices…
           </div>
-        ) : notices.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center text-sm font-semibold text-slate-500">
-            No notices yet. Be the first to post.
-          </div>
         ) : (
-          <ul className="flex max-h-72 flex-col gap-3 overflow-y-auto pr-1 text-sm">
-            {notices.map((notice) => {
-              const isOwnNotice = notice.author === username;
-              const displayName = isOwnNotice ? 'You' : notice.author;
-              return (
-                <li
-                  key={notice.id}
-                  className={`rounded-2xl border px-4 py-3 shadow-sm transition ${
-                    isOwnNotice
-                      ? 'border-emerald-300/70 bg-gradient-to-br from-emerald-400/25 via-emerald-400/15 to-blue-400/15 text-emerald-800 shadow-[0_18px_45px_-32px_rgba(16,185,129,0.7)]'
-                      : 'border-white/35 bg-white/60 text-slate-700 shadow-[0_18px_45px_-32px_rgba(15,23,42,0.25)]'
-                  }`}
-                >
-                  <div className="flex items-baseline gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                    <span className="text-slate-600">{displayName}</span>
-                    {notice.timestamp && (
-                      <time dateTime={notice.timestamp} className="text-slate-400">
-                        {formatTimestamp(notice.timestamp)}
-                      </time>
-                    )}
-                  </div>
-                  <p className="mt-2 whitespace-pre-wrap text-sm font-medium text-slate-700">
-                    {notice.message}
-                  </p>
-                </li>
-              );
-            })}
-          </ul>
+          <NoticeTimeline notices={notices} username={username} />
         )}
       </div>
-      <form className="relative z-10 flex flex-col gap-3" onSubmit={handleSubmit}>
-        <textarea
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          placeholder="Post a new notice for the team"
-          rows={3}
-          maxLength={2000}
-          disabled={isPosting}
-          className="w-full rounded-2xl border border-white/35 bg-white/45 px-4 py-3 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60 disabled:cursor-not-allowed disabled:opacity-60"
-        />
-        <div className="flex items-center justify-between text-xs font-semibold text-slate-400 sm:text-sm">
-          <span>{draft.length}/2000</span>
-          <button
-            type="submit"
-            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-            disabled={isSubmittingDisabled}
-          >
-            {isPosting ? 'Posting…' : 'Post notice'}
-          </button>
-        </div>
-      </form>
+      <NoticeComposer draft={draft} onChange={setDraft} onSubmit={handleSubmit} disabled={isPosting} />
     </div>
   );
 };

--- a/frontend-next/src/components/StorageIndicator.jsx
+++ b/frontend-next/src/components/StorageIndicator.jsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react';
+import { getStorageStatus } from '../services/api.js';
+
+const REFRESH_INTERVAL_MS = 30000;
+
+const formatBytes = (value) => {
+  if (!Number.isFinite(value) || value < 0) {
+    return 'N/A';
+  }
+  if (value === 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  let index = 0;
+  let current = value;
+  while (current >= 1024 && index < units.length - 1) {
+    current /= 1024;
+    index += 1;
+  }
+  const precision = current >= 100 ? 0 : current >= 10 ? 1 : 2;
+  return `${current.toFixed(precision)} ${units[index]}`;
+};
+
+const formatPercentage = (value) => {
+  if (!Number.isFinite(value)) {
+    return 'N/A';
+  }
+  return `${Math.round(value)}%`;
+};
+
+const StorageIndicator = () => {
+  const [state, setState] = useState({ info: null, loading: true, error: '' });
+
+  useEffect(() => {
+    let active = true;
+    let timerId = null;
+
+    const fetchStatus = async () => {
+      try {
+        const data = await getStorageStatus();
+        if (!active) {
+          return;
+        }
+        setState({ info: data, loading: false, error: '' });
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        setState((prev) => ({
+          info: prev.info,
+          loading: false,
+          error: error?.message || 'Unable to load storage status',
+        }));
+      } finally {
+        if (!active) {
+          return;
+        }
+        timerId = setTimeout(fetchStatus, REFRESH_INTERVAL_MS);
+      }
+    };
+
+    fetchStatus();
+
+    return () => {
+      active = false;
+      if (timerId) {
+        clearTimeout(timerId);
+      }
+    };
+  }, []);
+
+  const { info, loading, error } = state;
+
+  if (!info && !loading && error) {
+    return (
+      <span className="glass-chip storage-indicator" title={error}>
+        Storage unavailable
+      </span>
+    );
+  }
+
+  if (!info) {
+    return (
+      <span className="glass-chip storage-indicator" aria-live="polite">
+        Checking storage...
+      </span>
+    );
+  }
+
+  const { freeBytes, totalBytes, usedBytes, freePercentage, usedPercentage } = info;
+  const formattedFree = formatBytes(freeBytes);
+  const formattedTotal = formatBytes(totalBytes);
+  const formattedUsed = formatBytes(usedBytes);
+  const freePercentText = formatPercentage(freePercentage);
+  const usedPercentText = formatPercentage(usedPercentage);
+
+  const tooltip = `Free: ${formattedFree} (${freePercentText})\nUsed: ${formattedUsed} (${usedPercentText})\nTotal: ${formattedTotal}`;
+
+  return (
+    <span className="glass-chip storage-indicator" title={tooltip} aria-live="polite">
+      Free {formattedFree}
+    </span>
+  );
+};
+
+export default StorageIndicator;

--- a/frontend-next/src/components/UserManagementPanel.jsx
+++ b/frontend-next/src/components/UserManagementPanel.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import useDialog from './dialog/useDialog.js';
 import { fetchUsers, createUser, updateUser, deleteUser } from '../services/api.js';
 
 const normalizePath = (input) => {
@@ -31,6 +32,7 @@ const initialNewUser = {
 };
 
 const UserManagementPanel = ({ onUsersChanged }) => {
+  const dialog = useDialog();
   const [users, setUsers] = useState([]);
   const [selectedUsername, setSelectedUsername] = useState('');
   const [accessDraft, setAccessDraft] = useState([]);
@@ -155,7 +157,12 @@ const UserManagementPanel = ({ onUsersChanged }) => {
     }
     setError('');
     setMessage('');
-    const password = window.prompt(`Enter a new password for ${selectedUser.username}`);
+    const password = await dialog.prompt({
+      title: 'Reset password',
+      message: `Enter a new password for ${selectedUser.username}.`,
+      placeholder: 'New password',
+      inputType: 'password',
+    });
     if (!password) {
       setMessage('Password update cancelled.');
       return;
@@ -183,7 +190,12 @@ const UserManagementPanel = ({ onUsersChanged }) => {
     }
     setError('');
     setMessage('');
-    const confirmed = window.confirm(`Remove user “${selectedUser.username}”?`);
+    const confirmed = await dialog.confirm({
+      title: 'Remove user',
+      message: `Remove user “${selectedUser.username}”?`,
+      confirmLabel: 'Remove user',
+      destructive: true,
+    });
     if (!confirmed) {
       return;
     }

--- a/frontend-next/src/components/admin/AccountSettingsCard.jsx
+++ b/frontend-next/src/components/admin/AccountSettingsCard.jsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { updateMyProfile } from '../../services/api.js';
+
+const AccountSettingsCard = ({ user, onProfileUpdated }) => {
+  const [username, setUsername] = useState(user.username);
+  const [status, setStatus] = useState({ error: '', success: '' });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setUsername(user.username);
+  }, [user.username]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ error: '', success: '' });
+    const trimmed = username.trim();
+    if (!trimmed) {
+      setStatus({ error: 'Username cannot be empty.', success: '' });
+      return;
+    }
+    if (trimmed === user.username) {
+      setStatus({ error: '', success: 'Username is already up to date.' });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await updateMyProfile({ username: trimmed });
+      setStatus({ error: '', success: 'Username updated successfully.' });
+      onProfileUpdated?.();
+    } catch (err) {
+      setStatus({ error: err.message || 'Unable to update username.', success: '' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="glass-panel relative flex flex-col gap-5 overflow-hidden p-6" onSubmit={handleSubmit}>
+      <div className="pointer-events-none chroma-grid" />
+      <div className="relative z-10 space-y-2">
+        <h2 className="text-lg font-bold text-slate-900 sm:text-xl">Account profile</h2>
+        <p className="text-sm font-medium text-slate-600">
+          Update your administrator username and review account metadata.
+        </p>
+      </div>
+      {status.error && (
+        <div className="relative z-10 rounded-2xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]">
+          {status.error}
+        </div>
+      )}
+      {status.success && (
+        <div className="relative z-10 rounded-2xl border border-emerald-200/70 bg-emerald-100/75 px-4 py-3 text-sm font-semibold text-emerald-600 shadow-[0_12px_30px_-18px_rgba(16,185,129,0.4)]">
+          {status.success}
+        </div>
+      )}
+      <div className="relative z-10 grid gap-4 sm:grid-cols-2">
+        <label className="flex flex-col gap-2 text-xs font-semibold text-slate-600 sm:text-sm sm:col-span-2">
+          <span>Username</span>
+          <input
+            type="text"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            autoComplete="username"
+            placeholder="Administrator username"
+            className="rounded-2xl border border-white/45 bg-white/55 px-4 py-2.5 text-sm font-medium text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60"
+          />
+        </label>
+        <div className="flex flex-col gap-2 rounded-2xl border border-white/35 bg-white/60 p-4 text-xs text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] sm:text-sm">
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Role</span>
+          <span className="text-base font-semibold text-slate-700">{user.role}</span>
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Created</span>
+          <time dateTime={user.createdAt} className="font-semibold text-slate-700">
+            {user.createdAt ? new Date(user.createdAt).toLocaleString() : '—'}
+          </time>
+        </div>
+        <div className="flex flex-col gap-2 rounded-2xl border border-white/35 bg-white/60 p-4 text-xs text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] sm:text-sm">
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Last updated</span>
+          <time dateTime={user.updatedAt} className="text-base font-semibold text-slate-700">
+            {user.updatedAt ? new Date(user.updatedAt).toLocaleString() : '—'}
+          </time>
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Access entries</span>
+          <span className="text-base font-semibold text-slate-700">{user.access?.length || 0}</span>
+        </div>
+      </div>
+      <div className="relative z-10 flex items-center justify-end">
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AccountSettingsCard;

--- a/frontend-next/src/components/admin/AdminControlPanel.jsx
+++ b/frontend-next/src/components/admin/AdminControlPanel.jsx
@@ -1,0 +1,13 @@
+const AdminControlPanel = ({
+  primary,
+  secondary,
+  tertiary,
+}) => (
+  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+    <div className="flex flex-col gap-6">{primary}</div>
+    <div className="flex flex-col gap-6">{secondary}</div>
+    {tertiary ? <div className="flex flex-col gap-6 xl:col-span-2">{tertiary}</div> : null}
+  </div>
+);
+
+export default AdminControlPanel;

--- a/frontend-next/src/components/admin/AdminHero.jsx
+++ b/frontend-next/src/components/admin/AdminHero.jsx
@@ -1,0 +1,38 @@
+const AdminHero = ({ user, onOpenSettings }) => (
+  <header className="glass-panel relative flex flex-col gap-5 overflow-hidden p-6 sm:flex-row sm:items-center sm:justify-between">
+    <div className="pointer-events-none chroma-grid" />
+    <div className="relative z-10 space-y-3">
+      <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">
+        Admin Control Center
+      </div>
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-[2.1rem]">
+          Welcome, {user.username}
+        </h1>
+        <p className="max-w-xl text-sm font-medium text-slate-600 sm:text-base">
+          Manage teams, notices, and procurement from a streamlined workspace. Open settings to adjust
+          your own account and system preferences.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-blue-700">
+        <span className="glass-chip">Administrator</span>
+        <span className="glass-chip">Full access</span>
+      </div>
+    </div>
+    <div className="relative z-10 flex flex-col items-end gap-3">
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/40 px-5 py-2 text-sm font-semibold text-slate-700 shadow-[0_20px_45px_-24px_rgba(15,23,42,0.35)] transition hover:bg-white/55 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+      >
+        <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+        Workspace settings
+      </button>
+      <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+        Role: {user.role}
+      </p>
+    </div>
+  </header>
+);
+
+export default AdminHero;

--- a/frontend-next/src/components/admin/AdminSettingsOverlay.jsx
+++ b/frontend-next/src/components/admin/AdminSettingsOverlay.jsx
@@ -1,0 +1,31 @@
+import AccountSettingsCard from './AccountSettingsCard.jsx';
+import ChangePasswordForm from '../ChangePasswordForm.jsx';
+
+const AdminSettingsOverlay = ({ user, onClose, onProfileUpdated, onPasswordChange }) => (
+  <div className="fixed inset-0 z-[1100] flex items-center justify-center bg-slate-900/75 backdrop-blur">
+    <div className="relative flex max-h-[90vh] w-full max-w-5xl flex-col gap-6 overflow-y-auto rounded-3xl border border-white/20 bg-white/70 p-6 shadow-[0_40px_80px_-35px_rgba(15,23,42,0.65)]">
+      <div className="relative z-10 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-slate-900">Workspace settings</h2>
+          <p className="text-sm font-medium text-slate-600">
+            Adjust your administrator account, update your password, and manage personal preferences.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/50 bg-white/60 text-slate-600 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.35)] transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          aria-label="Close settings"
+        >
+          ×
+        </button>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <AccountSettingsCard user={user} onProfileUpdated={onProfileUpdated} />
+        <ChangePasswordForm title="Update your password" onSubmit={onPasswordChange} />
+      </div>
+    </div>
+  </div>
+);
+
+export default AdminSettingsOverlay;

--- a/frontend-next/src/components/dialog/DialogContext.jsx
+++ b/frontend-next/src/components/dialog/DialogContext.jsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export const DialogContext = createContext(null);
+
+export const useDialogContext = () => {
+  const context = useContext(DialogContext);
+  if (!context) {
+    throw new Error('useDialog must be used within a DialogProvider');
+  }
+  return context;
+};

--- a/frontend-next/src/components/dialog/DialogProvider.jsx
+++ b/frontend-next/src/components/dialog/DialogProvider.jsx
@@ -1,0 +1,194 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { DialogContext } from './DialogContext.jsx';
+
+const defaultLabels = {
+  confirmLabel: 'Confirm',
+  cancelLabel: 'Cancel',
+  acknowledgeLabel: 'OK',
+};
+
+const DialogOverlay = ({
+  dialog,
+  inputValue,
+  onInputChange,
+  onConfirm,
+  onCancel,
+}) => {
+  const {
+    title,
+    message,
+    variant,
+    confirmLabel,
+    cancelLabel,
+    acknowledgeLabel,
+    placeholder,
+    description,
+    destructive,
+  } = dialog;
+
+  const renderActions = () => {
+    if (variant === 'alert') {
+      return (
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="inline-flex min-w-[120px] items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          {acknowledgeLabel || defaultLabels.acknowledgeLabel}
+        </button>
+      );
+    }
+
+    return (
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex min-w-[120px] items-center justify-center rounded-full border border-white/40 bg-white/30 px-5 py-2.5 text-sm font-semibold text-slate-600 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.3)] transition hover:bg-white/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300"
+        >
+          {cancelLabel || defaultLabels.cancelLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className={`inline-flex min-w-[120px] items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+            destructive
+              ? 'bg-gradient-to-r from-rose-500 via-rose-500 to-orange-500 hover:shadow-[0_25px_55px_-20px_rgba(244,63,94,0.6)]'
+              : 'bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)]'
+          }`}
+        >
+          {confirmLabel || defaultLabels.confirmLabel}
+        </button>
+      </div>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-[1200] flex items-center justify-center bg-slate-900/70 backdrop-blur">
+      <div className="relative w-full max-w-lg rounded-3xl border border-white/20 bg-white/60 p-6 text-slate-900 shadow-[0_30px_70px_-30px_rgba(15,23,42,0.55)]">
+        <div className="pointer-events-none absolute inset-0 rounded-3xl border border-white/40" aria-hidden="true" />
+        <div className="relative space-y-4">
+          {title ? <h2 className="text-xl font-bold text-slate-900">{title}</h2> : null}
+          {description ? (
+            <p className="text-sm font-medium text-slate-600">{description}</p>
+          ) : null}
+          {message ? (
+            <p className="whitespace-pre-line text-sm font-medium text-slate-700">{message}</p>
+          ) : null}
+          {variant === 'prompt' ? (
+            <input
+              type={dialog.inputType || 'text'}
+              value={inputValue}
+              onChange={(event) => onInputChange(event.target.value)}
+              placeholder={placeholder}
+              className="w-full rounded-2xl border border-white/45 bg-white/55 px-4 py-2.5 text-sm font-medium text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60"
+              autoFocus
+            />
+          ) : null}
+          <div className="flex items-center justify-end gap-3 pt-2">{renderActions()}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const DialogProvider = ({ children }) => {
+  const [dialog, setDialog] = useState(null);
+  const [inputValue, setInputValue] = useState('');
+  const resolverRef = useRef(null);
+
+  const closeDialog = useCallback(
+    (result) => {
+      const resolver = resolverRef.current;
+      resolverRef.current = null;
+      setDialog(null);
+      setInputValue('');
+      if (resolver) {
+        resolver(result);
+      }
+    },
+    []
+  );
+
+  const openDialog = useCallback((nextDialog) => {
+    if (!nextDialog) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      resolverRef.current = resolve;
+      setInputValue(nextDialog.defaultValue || '');
+      setDialog(nextDialog);
+    });
+  }, []);
+
+  const confirm = useCallback(
+    (options = {}) =>
+      openDialog({ variant: 'confirm', destructive: Boolean(options.destructive), ...options }).then(
+        (result) => Boolean(result && result.confirmed)
+      ),
+    [openDialog]
+  );
+
+  const alert = useCallback(
+    (options = {}) =>
+      openDialog({ variant: 'alert', ...options }).then((result) => Boolean(result && result.confirmed)),
+    [openDialog]
+  );
+
+  const prompt = useCallback(
+    (options = {}) =>
+      openDialog({ variant: 'prompt', ...options }).then((result) => {
+        if (!result || !result.confirmed) {
+          return null;
+        }
+        return 'value' in result ? result.value : inputValue;
+      }),
+    [openDialog, inputValue]
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (!dialog) {
+      return;
+    }
+    if (dialog.variant === 'prompt') {
+      closeDialog({ confirmed: true, value: inputValue });
+      return;
+    }
+    closeDialog({ confirmed: true });
+  }, [closeDialog, dialog, inputValue]);
+
+  const handleCancel = useCallback(() => {
+    closeDialog({ confirmed: false });
+  }, [closeDialog]);
+
+  const contextValue = useMemo(
+    () => ({
+      confirm,
+      alert,
+      prompt,
+    }),
+    [alert, confirm, prompt]
+  );
+
+  return (
+    <DialogContext.Provider value={contextValue}>
+      {children}
+      {dialog ? (
+        <DialogOverlay
+          dialog={dialog}
+          inputValue={inputValue}
+          onInputChange={setInputValue}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      ) : null}
+    </DialogContext.Provider>
+  );
+};
+
+export default DialogProvider;

--- a/frontend-next/src/components/dialog/useDialog.js
+++ b/frontend-next/src/components/dialog/useDialog.js
@@ -1,0 +1,5 @@
+import { useDialogContext } from './DialogContext.jsx';
+
+const useDialog = () => useDialogContext();
+
+export default useDialog;

--- a/frontend-next/src/components/layout/AppShell.jsx
+++ b/frontend-next/src/components/layout/AppShell.jsx
@@ -1,0 +1,94 @@
+import StorageIndicator from '../StorageIndicator.jsx';
+
+const Orb = ({ style }) => (
+  <div className="orb-glow" style={style} />
+);
+
+const AppShell = ({ align = 'stretch', user, onLogout, children }) => {
+  const mainClass = align === 'center' ? 'app-main app-main--center' : 'app-main';
+
+  return (
+    <div className="app-shell">
+      <div className="app-shell__layer">
+        <Orb
+          style={{
+            top: '-22%',
+            left: '-10%',
+            width: '540px',
+            height: '540px',
+            background: 'radial-gradient(circle, rgba(59,130,246,0.3), transparent 65%)',
+          }}
+        />
+        <Orb
+          style={{
+            bottom: '-28%',
+            right: '-14%',
+            width: '620px',
+            height: '620px',
+            background: 'radial-gradient(circle, rgba(236,72,153,0.24), transparent 68%)',
+          }}
+        />
+        <Orb
+          style={{
+            top: '30%',
+            right: '12%',
+            width: '320px',
+            height: '320px',
+            background: 'radial-gradient(circle, rgba(56,189,248,0.3), transparent 62%)',
+          }}
+        />
+      </div>
+      <div className="app-shell__inner">
+        <header className="app-topbar glass-panel backdrop-sheen">
+          <div className="app-brand">
+            <span className="app-brand__mark">HTS</span>
+            <div>
+              <span className="app-brand__title">Network Access Storage</span>
+              <span className="app-brand__subtitle">Fluid workspace</span>
+            </div>
+          </div>
+          {user ? (
+            <div className="app-topbar__meta">
+              <StorageIndicator />
+              <div className="app-topbar__user">
+                <span>{user.username}</span>
+                <span className="app-topbar__chip">{user.role}</span>
+              </div>
+              <button type="button" className="app-topbar__logout" onClick={onLogout}>
+                Sign out
+              </button>
+            </div>
+          ) : (
+            <span className="glass-chip">Secure access</span>
+          )}
+        </header>
+        <main className={mainClass}>
+          <div className="app-main__background">
+            <div className="chroma-grid" />
+            <Orb
+              style={{
+                top: '-18%',
+                left: '12%',
+                width: '320px',
+                height: '320px',
+                background: 'radial-gradient(circle, rgba(59,130,246,0.35), transparent 62%)',
+              }}
+            />
+            <Orb
+              style={{
+                bottom: '-24%',
+                right: '-10%',
+                width: '420px',
+                height: '420px',
+                background: 'radial-gradient(circle, rgba(99,102,241,0.28), transparent 65%)',
+              }}
+            />
+          </div>
+          <div className="app-main__content">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/frontend-next/src/services/api.js
+++ b/frontend-next/src/services/api.js
@@ -254,6 +254,10 @@ async function request(path, options = {}) {
   return payload;
 }
 
+export function getStorageStatus() {
+  return request('/storage/status');
+}
+
 export function listItems(path = '') {
   const params = new URLSearchParams();
   if (path) {
@@ -377,6 +381,34 @@ export function renameItem(path, newName, password) {
   });
 }
 
+export function copyItem(source, destination, { newName, password } = {}) {
+  const payload = { source, destination };
+  if (newName) {
+    payload.newName = newName;
+  }
+  if (password) {
+    payload.password = password;
+  }
+  return request('/items/copy', {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export function moveItem(source, destination, { newName, password } = {}) {
+  const payload = { source, destination };
+  if (newName) {
+    payload.newName = newName;
+  }
+  if (password) {
+    payload.password = password;
+  }
+  return request('/items/move', {
+    method: 'POST',
+    body: payload,
+  });
+}
+
 export function lockItem(path, password) {
   return request('/items/lock', {
     method: 'POST',
@@ -468,6 +500,13 @@ export function logout() {
 
 export function getCurrentUser() {
   return request('/auth/me');
+}
+
+export function updateMyProfile(body) {
+  return request('/users/me/profile', {
+    method: 'PUT',
+    body,
+  });
 }
 
 export function changeMyPassword(currentPassword, newPassword) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,8 @@ import DepartmentHeadDashboard from './components/DepartmentHeadDashboard.jsx';
 import FinanceDashboard from './components/FinanceDashboard.jsx';
 import ProcurementDashboard from './components/ProcurementDashboard.jsx';
 import LoginForm from './components/LoginForm.jsx';
-import StorageIndicator from './components/StorageIndicator.jsx';
+import DialogProvider from './components/dialog/DialogProvider.jsx';
+import AppShell from './components/layout/AppShell.jsx';
 import {
   setAuthToken,
   login as apiLogin,
@@ -87,162 +88,48 @@ const App = () => {
     await refreshUser();
   };
 
-  const renderShell = ({ content, align = 'stretch', user = null }) => {
-    const mainClass = align === 'center' ? 'app-main app-main--center' : 'app-main';
-
-    return (
-      <div className="app-shell">
-        <div className="app-shell__layer">
-          <div
-            className="orb-glow"
-            style={{
-              top: '-22%',
-              left: '-10%',
-              width: '540px',
-              height: '540px',
-              background: 'radial-gradient(circle, rgba(59,130,246,0.3), transparent 65%)',
-            }}
-          />
-          <div
-            className="orb-glow"
-            style={{
-              bottom: '-28%',
-              right: '-14%',
-              width: '620px',
-              height: '620px',
-              background: 'radial-gradient(circle, rgba(236,72,153,0.24), transparent 68%)',
-            }}
-          />
-          <div
-            className="orb-glow"
-            style={{
-              top: '30%',
-              right: '12%',
-              width: '320px',
-              height: '320px',
-              background: 'radial-gradient(circle, rgba(56,189,248,0.3), transparent 62%)',
-            }}
-          />
-        </div>
-        <div className="app-shell__inner">
-          <header className="app-topbar glass-panel backdrop-sheen">
-            <div className="app-brand">
-              <span className="app-brand__mark">HTS</span>
-              <div>
-                <span className="app-brand__title">Network Access Storage</span>
-                <span className="app-brand__subtitle">Fluid workspace</span>
-              </div>
-            </div>
-            {user ? (
-              <div className="app-topbar__meta">
-                <StorageIndicator />
-                <div className="app-topbar__user">
-                  <span>{user.username}</span>
-                  <span className="app-topbar__chip">{user.role}</span>
-                </div>
-                <button type="button" className="app-topbar__logout" onClick={handleLogout}>
-                  Sign out
-                </button>
-              </div>
-            ) : (
-              <span className="glass-chip">Secure access</span>
-            )}
-          </header>
-          <main className={mainClass}>
-            <div className="app-main__background">
-              <div className="chroma-grid" />
-              <div
-                className="orb-glow"
-                style={{
-                  top: '-18%',
-                  left: '12%',
-                  width: '320px',
-                  height: '320px',
-                  background: 'radial-gradient(circle, rgba(59,130,246,0.35), transparent 62%)',
-                }}
-              />
-              <div
-                className="orb-glow"
-                style={{
-                  bottom: '-24%',
-                  right: '-10%',
-                  width: '420px',
-                  height: '420px',
-                  background: 'radial-gradient(circle, rgba(99,102,241,0.28), transparent 65%)',
-                }}
-              />
-            </div>
-            <div className="app-main__content">{content}</div>
-          </main>
-        </div>
-      </div>
-    );
-  };
+  let align = 'stretch';
+  let content = null;
+  const user = authState.status === 'authenticated' ? authState.user : null;
 
   if (authState.status === 'loading') {
-    return renderShell({
-      align: 'center',
-      content: (
-        <div className="flex flex-col items-center gap-4 text-center text-slate-200">
-          <span className="glass-chip text-xs tracking-[0.35em] text-blue-700">Loading…</span>
-          <p className="text-sm font-medium text-slate-400">
-            Preparing your storage workspace. Please hold on for a moment.
-          </p>
-        </div>
-      ),
-    });
+    align = 'center';
+    content = (
+      <div className="flex flex-col items-center gap-4 text-center text-slate-200">
+        <span className="glass-chip text-xs tracking-[0.35em] text-blue-700">Loading…</span>
+        <p className="text-sm font-medium text-slate-400">
+          Preparing your storage workspace. Please hold on for a moment.
+        </p>
+      </div>
+    );
+  } else if (!user) {
+    align = 'center';
+    content = (
+      <div className="mx-auto w-full max-w-xl">
+        <LoginForm onSubmit={handleLogin} error={authError} />
+      </div>
+    );
+  } else if (user.role === 'admin') {
+    content = (
+      <AdminDashboard user={user} onPasswordChange={handlePasswordChange} onRefreshUser={refreshUser} />
+    );
+  } else if (user.role === 'dept-head') {
+    content = <DepartmentHeadDashboard user={user} onPasswordChange={handlePasswordChange} />;
+  } else if (user.role === 'finance') {
+    content = <FinanceDashboard user={user} onPasswordChange={handlePasswordChange} />;
+  } else if (user.role === 'procurement') {
+    content = <ProcurementDashboard user={user} onPasswordChange={handlePasswordChange} />;
+  } else {
+    content = <UserDashboard user={user} onPasswordChange={handlePasswordChange} />;
   }
 
-  if (authState.status !== 'authenticated' || !authState.user) {
-    return renderShell({
-      align: 'center',
-      content: (
-        <div className="mx-auto w-full max-w-xl">
-          <LoginForm onSubmit={handleLogin} error={authError} />
-        </div>
-      ),
-    });
-  }
-
-  const { user } = authState;
-  if (user.role === 'admin') {
-    return renderShell({
-    user,
-      content: (
-        <AdminDashboard
-          user={user}
-          onPasswordChange={handlePasswordChange}
-          onRefreshUser={refreshUser}
-        />
-      ),
-    });
-  }
-
-  if (user.role === 'dept-head') {
-    return renderShell({
-      user,
-      content: <DepartmentHeadDashboard user={user} onPasswordChange={handlePasswordChange} />,
-    });
-  }
-
-  if (user.role === 'finance') {
-    return renderShell({
-      user,
-      content: <FinanceDashboard user={user} onPasswordChange={handlePasswordChange} />,
-    });
-  }
-
-  if (user.role === 'procurement') {
-    return renderShell({
-      user,
-      content: <ProcurementDashboard user={user} onPasswordChange={handlePasswordChange} />,
-    });
-  }
-
-  return renderShell({
-    user,
-    content: <UserDashboard user={user} onPasswordChange={handlePasswordChange} />,
-  });
+  return (
+    <DialogProvider>
+      <AppShell align={align} user={user} onLogout={handleLogout}>
+        {content}
+      </AppShell>
+    </DialogProvider>
+  );
 };
 
 export default App;

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,58 +1,48 @@
+import { useState } from 'react';
 import FileManager from './FileManager.jsx';
 import UserManagementPanel from './UserManagementPanel.jsx';
-import ChangePasswordForm from './ChangePasswordForm.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
+import AdminHero from './admin/AdminHero.jsx';
+import AdminControlPanel from './admin/AdminControlPanel.jsx';
+import AdminSettingsOverlay from './admin/AdminSettingsOverlay.jsx';
 
-const AdminDashboard = ({ user, onPasswordChange, onRefreshUser }) => (
-  <div className="flex flex-col gap-7 text-slate-900">
-    <header className="glass-panel relative flex flex-col gap-4 overflow-hidden p-5 sm:flex-row sm:items-center sm:justify-between">
-      <div className="pointer-events-none chroma-grid" />
-      <div className="relative z-10 space-y-2">
-        <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">
-          Admin Control
-        </div>
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight sm:text-[2rem]">
-            Welcome, {user.username}
-          </h1>
-          <p className="text-sm font-medium text-slate-600 sm:text-base">
-            You have administrator access to the HTS NAS.
-          </p>
-        </div>
-      </div>
-      <span className="relative z-10 glass-chip text-xs tracking-[0.35em] text-blue-700">Administrator</span>
-    </header>
+const AdminDashboard = ({ user, onPasswordChange, onRefreshUser }) => {
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
-    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.55fr)_minmax(0,1fr)]">
-      <div className="flex flex-col gap-6">
-        <section>
-          <FileManager
-            title="NAS file explorer"
-            subtitle="Manage all files and folders stored on the NAS."
-          />
-        </section>
+  return (
+    <div className="flex flex-col gap-7 text-slate-900">
+      <AdminHero user={user} onOpenSettings={() => setSettingsOpen(true)} />
 
-        <section>
-          <UserManagementPanel onUsersChanged={onRefreshUser} />
-        </section>
-      </div>
+      <AdminControlPanel
+        primary={[
+          <section key="file-manager">
+            <FileManager title="NAS file explorer" subtitle="Manage all files and folders stored on the NAS." />
+          </section>,
+          <section key="user-management">
+            <UserManagementPanel onUsersChanged={onRefreshUser} />
+          </section>,
+        ]}
+        secondary={[
+          <section key="protocols">
+            <ProtocolHub />
+          </section>,
+          <section key="notices">
+            <NoticeBoard currentUser={user} />
+          </section>,
+        ]}
+      />
 
-      <div className="flex flex-col gap-6">
-        <section>
-          <ProtocolHub />
-        </section>
-
-        <section>
-          <NoticeBoard currentUser={user} />
-        </section>
-
-        <section>
-          <ChangePasswordForm title="Update your administrator password" onSubmit={onPasswordChange} />
-        </section>
-      </div>
+      {settingsOpen ? (
+        <AdminSettingsOverlay
+          user={user}
+          onClose={() => setSettingsOpen(false)}
+          onProfileUpdated={onRefreshUser}
+          onPasswordChange={onPasswordChange}
+        />
+      ) : null}
     </div>
-  </div>
-);
+  );
+};
 
 export default AdminDashboard;

--- a/frontend/src/components/FileManager.jsx
+++ b/frontend/src/components/FileManager.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import useDialog from './dialog/useDialog.js';
 import Breadcrumbs from './Breadcrumbs.jsx';
 import FileList from './FileList.jsx';
 import QuickLook from './QuickLook.jsx';
@@ -99,6 +100,7 @@ const FileManager = ({
   allowViewToggle = true,
   passwordLookup,
 }) => {
+  const dialog = useDialog();
   const normalizedRoot = useMemo(() => sanitizePath(rootPath), [rootPath]);
   const normalizedInitial = useMemo(() => sanitizePath(initialPath), [initialPath]);
   const startingPath = normalizedInitial || normalizedRoot || '';
@@ -486,9 +488,12 @@ const FileManager = ({
       const stored = getStoredPassword(sourcePath);
       password = stored;
       if (!password) {
-        const input = window.prompt(
-          `Enter the password to ${mode === 'copy' ? 'copy' : 'move'} this locked item`
-        );
+        const input = await dialog.prompt({
+          title: 'Password required',
+          message: `Enter the password to ${mode === 'copy' ? 'copy' : 'move'} this locked item.`,
+          placeholder: 'Enter password',
+          inputType: 'password',
+        });
         if (!input) {
           setMessage(`${mode === 'copy' ? 'Copy' : 'Move'} cancelled`);
           return false;
@@ -648,7 +653,11 @@ const FileManager = ({
     if (!allowCreate) {
       return;
     }
-    const name = window.prompt('Folder name');
+    const name = await dialog.prompt({
+      title: 'Create folder',
+      message: 'Enter a name for the new folder.',
+      placeholder: 'Folder name',
+    });
     if (!name) {
       return;
     }
@@ -743,9 +752,12 @@ const FileManager = ({
     if (!allowDelete) {
       return;
     }
-    const confirmed = window.confirm(
-      `Delete ${item.type === 'directory' ? 'folder' : 'file'} “${item.name}”?`
-    );
+    const confirmed = await dialog.confirm({
+      title: 'Delete item',
+      message: `Delete ${item.type === 'directory' ? 'folder' : 'file'} “${item.name}”?`,
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
     if (!confirmed) {
       return;
     }
@@ -753,7 +765,12 @@ const FileManager = ({
     if (item.isLocked) {
       password = getStoredPassword(item.path || joinPath(currentPath, item.name));
       if (!password) {
-        password = window.prompt('Enter the password to delete this locked item');
+        password = await dialog.prompt({
+          title: 'Password required',
+          message: 'Enter the password to delete this locked item.',
+          placeholder: 'Enter password',
+          inputType: 'password',
+        });
       }
       if (!password) {
         setMessage('Deletion cancelled');
@@ -771,7 +788,12 @@ const FileManager = ({
     if (!allowRename) {
       return;
     }
-    const newName = window.prompt('Enter the new name', item.name);
+    const newName = await dialog.prompt({
+      title: 'Rename item',
+      message: 'Enter a new name for the selected item.',
+      placeholder: 'New name',
+      defaultValue: item.name,
+    });
     if (!newName) {
       return;
     }
@@ -788,7 +810,12 @@ const FileManager = ({
     if (item.isLocked) {
       password = getStoredPassword(item.path || joinPath(currentPath, item.name));
       if (!password) {
-        password = window.prompt('Enter the password to rename this locked item');
+        password = await dialog.prompt({
+          title: 'Password required',
+          message: 'Enter the password to rename this locked item.',
+          placeholder: 'Enter password',
+          inputType: 'password',
+        });
       }
       if (!password) {
         setMessage('Rename cancelled');
@@ -809,7 +836,14 @@ const FileManager = ({
     const targetPath = item.path || joinPath(currentPath, item.name);
     if (item.isLocked) {
       const stored = getStoredPassword(targetPath);
-      const password = stored || window.prompt('Enter the password to unlock this item');
+      const password =
+        stored ||
+        (await dialog.prompt({
+          title: 'Password required',
+          message: 'Enter the password to unlock this item.',
+          placeholder: 'Enter password',
+          inputType: 'password',
+        }));
       if (!password) {
         setMessage('Unlock cancelled');
         return;
@@ -821,7 +855,12 @@ const FileManager = ({
       return;
     }
 
-    const password = window.prompt('Set a password to lock this item');
+    const password = await dialog.prompt({
+      title: 'Lock item',
+      message: 'Set a password to lock this item.',
+      placeholder: 'Create password',
+      inputType: 'password',
+    });
     if (!password) {
       setMessage('Lock cancelled');
       return;
@@ -857,7 +896,12 @@ const FileManager = ({
     if (item.isLocked) {
       password = getStoredPassword(item.path || joinPath(currentPath, item.name));
       if (!password) {
-        const input = window.prompt('Enter the password to preview this locked file');
+        const input = await dialog.prompt({
+          title: 'Password required',
+          message: 'Enter the password to preview this locked file.',
+          placeholder: 'Enter password',
+          inputType: 'password',
+        });
         if (!input) {
           setMessage('Preview cancelled');
           return;
@@ -926,7 +970,12 @@ const FileManager = ({
     if (item.isLocked) {
       password = getStoredPassword(item.path || joinPath(currentPath, item.name));
       if (!password) {
-        const input = window.prompt('Enter the password to download this locked file');
+        const input = await dialog.prompt({
+          title: 'Password required',
+          message: 'Enter the password to download this locked file.',
+          placeholder: 'Enter password',
+          inputType: 'password',
+        });
         if (!input) {
           setMessage('Download cancelled');
           return;

--- a/frontend/src/components/NoticeBoard.jsx
+++ b/frontend/src/components/NoticeBoard.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { fetchNotices, createNotice } from '../services/api.js';
 
 const formatTimestamp = (timestamp) => {
@@ -11,6 +11,82 @@ const formatTimestamp = (timestamp) => {
   }
   return date.toLocaleString([], { dateStyle: 'short', timeStyle: 'short' });
 };
+
+const NoticeBadge = ({ label }) => (
+  <span className="rounded-full border border-white/40 bg-white/45 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-blue-600">
+    {label}
+  </span>
+);
+
+const NoticeItem = ({ notice, isOwn }) => (
+  <li
+    className={`relative rounded-2xl border px-4 py-3 shadow-sm transition ${
+      isOwn
+        ? 'border-emerald-300/70 bg-gradient-to-br from-emerald-400/25 via-emerald-400/15 to-blue-400/15 text-emerald-800 shadow-[0_18px_45px_-32px_rgba(16,185,129,0.7)]'
+        : 'border-white/35 bg-white/60 text-slate-700 shadow-[0_18px_45px_-32px_rgba(15,23,42,0.25)]'
+    }`}
+  >
+    <div className="flex items-baseline justify-between gap-3 text-xs font-semibold uppercase tracking-wide text-slate-400">
+      <div className="flex items-baseline gap-2">
+        <span className="text-slate-600">{isOwn ? 'You' : notice.author}</span>
+        {notice.timestamp ? (
+          <time dateTime={notice.timestamp} className="text-slate-400">
+            {formatTimestamp(notice.timestamp)}
+          </time>
+        ) : null}
+      </div>
+      <span className="rounded-full border border-white/40 bg-white/30 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.25em] text-blue-500">
+        Notice
+      </span>
+    </div>
+    <p className="mt-2 whitespace-pre-wrap text-sm font-medium text-slate-700">{notice.message}</p>
+  </li>
+);
+
+const NoticeTimeline = ({ notices, username }) => {
+  if (!notices.length) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 rounded-2xl border border-white/35 bg-white/60 p-6 text-center text-sm font-semibold text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+        <span className="text-xs uppercase tracking-[0.35em] text-blue-500">No notices</span>
+        <p className="max-w-sm text-sm font-medium text-slate-600">
+          Be the first to share an update with your team.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex max-h-72 flex-col gap-3 overflow-y-auto pr-1 text-sm">
+      {notices.map((notice) => (
+        <NoticeItem key={notice.id} notice={notice} isOwn={notice.author === username} />
+      ))}
+    </ul>
+  );
+};
+
+const NoticeComposer = ({ draft, onChange, onSubmit, disabled }) => (
+  <form className="relative z-10 flex flex-col gap-3" onSubmit={onSubmit}>
+    <textarea
+      value={draft}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder="Post a new notice for the team"
+      rows={3}
+      maxLength={2000}
+      disabled={disabled}
+      className="w-full rounded-2xl border border-white/35 bg-white/45 px-4 py-3 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60 disabled:cursor-not-allowed disabled:opacity-60"
+    />
+    <div className="flex flex-wrap items-center justify-between gap-3 text-xs font-semibold text-slate-400 sm:text-sm">
+      <span>{draft.length}/2000</span>
+      <button
+        type="submit"
+        className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+        disabled={disabled || !draft.trim()}
+      >
+        {disabled ? 'Posting…' : 'Post notice'}
+      </button>
+    </div>
+  </form>
+);
 
 const NoticeBoard = ({ currentUser }) => {
   const username = currentUser?.username || '';
@@ -96,97 +172,62 @@ const NoticeBoard = ({ currentUser }) => {
     [draft, isPosting, loadNotices]
   );
 
-  const isSubmittingDisabled = !draft.trim() || isPosting;
+  const stats = useMemo(() => {
+    const latest = notices[0];
+    return {
+      total: notices.length,
+      latestAt: latest?.timestamp ? formatTimestamp(latest.timestamp) : null,
+    };
+  }, [notices]);
 
   return (
-    <div className="glass-panel relative flex h-full flex-col gap-6 overflow-hidden p-5">
+    <div className="glass-panel relative flex h-full flex-col gap-6 overflow-hidden p-6">
       <div className="pointer-events-none chroma-grid" />
-      <div
-        className="orb-glow"
-        style={{
-          top: '-24%',
-          right: '-12%',
-          width: '280px',
-          height: '280px',
-          background: 'radial-gradient(circle, rgba(56,189,248,0.45), transparent 62%)',
-        }}
-      />
-      <div className="relative z-10 space-y-1">
-        <h2 className="text-lg font-bold text-slate-900 sm:text-xl">Team notices</h2>
-        <p className="text-sm font-medium text-slate-600">Share quick updates that everyone can see.</p>
-      </div>
-      {error && (
-        <div
-          className="relative z-10 rounded-2xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]"
-          role="alert"
-        >
-          {error}
+      <div className="relative z-10 flex flex-col gap-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <h2 className="text-lg font-bold text-slate-900 sm:text-xl">Team notices</h2>
+            <p className="text-sm font-medium text-slate-600">
+              Share quick updates that everyone can see. The board refreshes automatically every 10 seconds.
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-2 text-right text-xs font-semibold text-slate-500">
+            <div className="flex items-center gap-2">
+              <NoticeBadge label={`Total ${stats.total}`} />
+              <button
+                type="button"
+                onClick={() => loadNotices()}
+                className="inline-flex items-center gap-2 rounded-full border border-white/45 bg-white/40 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.3em] text-blue-600 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.3)] transition hover:bg-white/55 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              >
+                Refresh
+              </button>
+            </div>
+            {stats.latestAt ? (
+              <span className="text-[10px] uppercase tracking-[0.35em] text-slate-400">
+                Latest: {stats.latestAt}
+              </span>
+            ) : null}
+          </div>
         </div>
-      )}
-      <div
-        className="relative z-10 flex flex-1 flex-col gap-4 rounded-2xl border border-white/25 bg-white/30 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]"
-        aria-live="polite"
-      >
+        {error ? (
+          <div
+            className="relative z-10 rounded-2xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]"
+            role="alert"
+          >
+            {error}
+          </div>
+        ) : null}
+      </div>
+      <div className="relative z-10 flex flex-1 flex-col gap-4 rounded-2xl border border-white/25 bg-white/30 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
         {loading ? (
           <div className="flex flex-1 items-center justify-center text-sm font-semibold text-slate-500">
             Loading notices…
           </div>
-        ) : notices.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center text-sm font-semibold text-slate-500">
-            No notices yet. Be the first to post.
-          </div>
         ) : (
-          <ul className="flex max-h-72 flex-col gap-3 overflow-y-auto pr-1 text-sm">
-            {notices.map((notice) => {
-              const isOwnNotice = notice.author === username;
-              const displayName = isOwnNotice ? 'You' : notice.author;
-              return (
-                <li
-                  key={notice.id}
-                  className={`rounded-2xl border px-4 py-3 shadow-sm transition ${
-                    isOwnNotice
-                      ? 'border-emerald-300/70 bg-gradient-to-br from-emerald-400/25 via-emerald-400/15 to-blue-400/15 text-emerald-800 shadow-[0_18px_45px_-32px_rgba(16,185,129,0.7)]'
-                      : 'border-white/35 bg-white/60 text-slate-700 shadow-[0_18px_45px_-32px_rgba(15,23,42,0.25)]'
-                  }`}
-                >
-                  <div className="flex items-baseline gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                    <span className="text-slate-600">{displayName}</span>
-                    {notice.timestamp && (
-                      <time dateTime={notice.timestamp} className="text-slate-400">
-                        {formatTimestamp(notice.timestamp)}
-                      </time>
-                    )}
-                  </div>
-                  <p className="mt-2 whitespace-pre-wrap text-sm font-medium text-slate-700">
-                    {notice.message}
-                  </p>
-                </li>
-              );
-            })}
-          </ul>
+          <NoticeTimeline notices={notices} username={username} />
         )}
       </div>
-      <form className="relative z-10 flex flex-col gap-3" onSubmit={handleSubmit}>
-        <textarea
-          value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          placeholder="Post a new notice for the team"
-          rows={3}
-          maxLength={2000}
-          disabled={isPosting}
-          className="w-full rounded-2xl border border-white/35 bg-white/45 px-4 py-3 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60 disabled:cursor-not-allowed disabled:opacity-60"
-        />
-        <div className="flex items-center justify-between text-xs font-semibold text-slate-400 sm:text-sm">
-          <span>{draft.length}/2000</span>
-          <button
-            type="submit"
-            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
-            disabled={isSubmittingDisabled}
-          >
-            {isPosting ? 'Posting…' : 'Post notice'}
-          </button>
-        </div>
-      </form>
+      <NoticeComposer draft={draft} onChange={setDraft} onSubmit={handleSubmit} disabled={isPosting} />
     </div>
   );
 };

--- a/frontend/src/components/UserManagementPanel.jsx
+++ b/frontend/src/components/UserManagementPanel.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import useDialog from './dialog/useDialog.js';
 import { fetchUsers, createUser, updateUser, deleteUser } from '../services/api.js';
 
 const normalizePath = (input) => {
@@ -31,6 +32,7 @@ const initialNewUser = {
 };
 
 const UserManagementPanel = ({ onUsersChanged }) => {
+  const dialog = useDialog();
   const [users, setUsers] = useState([]);
   const [selectedUsername, setSelectedUsername] = useState('');
   const [accessDraft, setAccessDraft] = useState([]);
@@ -155,7 +157,12 @@ const UserManagementPanel = ({ onUsersChanged }) => {
     }
     setError('');
     setMessage('');
-    const password = window.prompt(`Enter a new password for ${selectedUser.username}`);
+    const password = await dialog.prompt({
+      title: 'Reset password',
+      message: `Enter a new password for ${selectedUser.username}.`,
+      placeholder: 'New password',
+      inputType: 'password',
+    });
     if (!password) {
       setMessage('Password update cancelled.');
       return;
@@ -183,7 +190,12 @@ const UserManagementPanel = ({ onUsersChanged }) => {
     }
     setError('');
     setMessage('');
-    const confirmed = window.confirm(`Remove user “${selectedUser.username}”?`);
+    const confirmed = await dialog.confirm({
+      title: 'Remove user',
+      message: `Remove user “${selectedUser.username}”?`,
+      confirmLabel: 'Remove user',
+      destructive: true,
+    });
     if (!confirmed) {
       return;
     }

--- a/frontend/src/components/admin/AccountSettingsCard.jsx
+++ b/frontend/src/components/admin/AccountSettingsCard.jsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { updateMyProfile } from '../../services/api.js';
+
+const AccountSettingsCard = ({ user, onProfileUpdated }) => {
+  const [username, setUsername] = useState(user.username);
+  const [status, setStatus] = useState({ error: '', success: '' });
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setUsername(user.username);
+  }, [user.username]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ error: '', success: '' });
+    const trimmed = username.trim();
+    if (!trimmed) {
+      setStatus({ error: 'Username cannot be empty.', success: '' });
+      return;
+    }
+    if (trimmed === user.username) {
+      setStatus({ error: '', success: 'Username is already up to date.' });
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await updateMyProfile({ username: trimmed });
+      setStatus({ error: '', success: 'Username updated successfully.' });
+      onProfileUpdated?.();
+    } catch (err) {
+      setStatus({ error: err.message || 'Unable to update username.', success: '' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form className="glass-panel relative flex flex-col gap-5 overflow-hidden p-6" onSubmit={handleSubmit}>
+      <div className="pointer-events-none chroma-grid" />
+      <div className="relative z-10 space-y-2">
+        <h2 className="text-lg font-bold text-slate-900 sm:text-xl">Account profile</h2>
+        <p className="text-sm font-medium text-slate-600">
+          Update your administrator username and review account metadata.
+        </p>
+      </div>
+      {status.error && (
+        <div className="relative z-10 rounded-2xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]">
+          {status.error}
+        </div>
+      )}
+      {status.success && (
+        <div className="relative z-10 rounded-2xl border border-emerald-200/70 bg-emerald-100/75 px-4 py-3 text-sm font-semibold text-emerald-600 shadow-[0_12px_30px_-18px_rgba(16,185,129,0.4)]">
+          {status.success}
+        </div>
+      )}
+      <div className="relative z-10 grid gap-4 sm:grid-cols-2">
+        <label className="flex flex-col gap-2 text-xs font-semibold text-slate-600 sm:text-sm sm:col-span-2">
+          <span>Username</span>
+          <input
+            type="text"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            autoComplete="username"
+            placeholder="Administrator username"
+            className="rounded-2xl border border-white/45 bg-white/55 px-4 py-2.5 text-sm font-medium text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60"
+          />
+        </label>
+        <div className="flex flex-col gap-2 rounded-2xl border border-white/35 bg-white/60 p-4 text-xs text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] sm:text-sm">
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Role</span>
+          <span className="text-base font-semibold text-slate-700">{user.role}</span>
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Created</span>
+          <time dateTime={user.createdAt} className="font-semibold text-slate-700">
+            {user.createdAt ? new Date(user.createdAt).toLocaleString() : '—'}
+          </time>
+        </div>
+        <div className="flex flex-col gap-2 rounded-2xl border border-white/35 bg-white/60 p-4 text-xs text-slate-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] sm:text-sm">
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Last updated</span>
+          <time dateTime={user.updatedAt} className="text-base font-semibold text-slate-700">
+            {user.updatedAt ? new Date(user.updatedAt).toLocaleString() : '—'}
+          </time>
+          <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-500">Access entries</span>
+          <span className="text-base font-semibold text-slate-700">{user.access?.length || 0}</span>
+        </div>
+      </div>
+      <div className="relative z-10 flex items-center justify-end">
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AccountSettingsCard;

--- a/frontend/src/components/admin/AdminControlPanel.jsx
+++ b/frontend/src/components/admin/AdminControlPanel.jsx
@@ -1,0 +1,13 @@
+const AdminControlPanel = ({
+  primary,
+  secondary,
+  tertiary,
+}) => (
+  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(0,1fr)]">
+    <div className="flex flex-col gap-6">{primary}</div>
+    <div className="flex flex-col gap-6">{secondary}</div>
+    {tertiary ? <div className="flex flex-col gap-6 xl:col-span-2">{tertiary}</div> : null}
+  </div>
+);
+
+export default AdminControlPanel;

--- a/frontend/src/components/admin/AdminHero.jsx
+++ b/frontend/src/components/admin/AdminHero.jsx
@@ -1,0 +1,38 @@
+const AdminHero = ({ user, onOpenSettings }) => (
+  <header className="glass-panel relative flex flex-col gap-5 overflow-hidden p-6 sm:flex-row sm:items-center sm:justify-between">
+    <div className="pointer-events-none chroma-grid" />
+    <div className="relative z-10 space-y-3">
+      <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">
+        Admin Control Center
+      </div>
+      <div className="space-y-1">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-[2.1rem]">
+          Welcome, {user.username}
+        </h1>
+        <p className="max-w-xl text-sm font-medium text-slate-600 sm:text-base">
+          Manage teams, notices, and procurement from a streamlined workspace. Open settings to adjust
+          your own account and system preferences.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.3em] text-blue-700">
+        <span className="glass-chip">Administrator</span>
+        <span className="glass-chip">Full access</span>
+      </div>
+    </div>
+    <div className="relative z-10 flex flex-col items-end gap-3">
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/40 px-5 py-2 text-sm font-semibold text-slate-700 shadow-[0_20px_45px_-24px_rgba(15,23,42,0.35)] transition hover:bg-white/55 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+      >
+        <span className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
+        Workspace settings
+      </button>
+      <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">
+        Role: {user.role}
+      </p>
+    </div>
+  </header>
+);
+
+export default AdminHero;

--- a/frontend/src/components/admin/AdminSettingsOverlay.jsx
+++ b/frontend/src/components/admin/AdminSettingsOverlay.jsx
@@ -1,0 +1,31 @@
+import AccountSettingsCard from './AccountSettingsCard.jsx';
+import ChangePasswordForm from '../ChangePasswordForm.jsx';
+
+const AdminSettingsOverlay = ({ user, onClose, onProfileUpdated, onPasswordChange }) => (
+  <div className="fixed inset-0 z-[1100] flex items-center justify-center bg-slate-900/75 backdrop-blur">
+    <div className="relative flex max-h-[90vh] w-full max-w-5xl flex-col gap-6 overflow-y-auto rounded-3xl border border-white/20 bg-white/70 p-6 shadow-[0_40px_80px_-35px_rgba(15,23,42,0.65)]">
+      <div className="relative z-10 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-slate-900">Workspace settings</h2>
+          <p className="text-sm font-medium text-slate-600">
+            Adjust your administrator account, update your password, and manage personal preferences.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/50 bg-white/60 text-slate-600 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.35)] transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          aria-label="Close settings"
+        >
+          ×
+        </button>
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <AccountSettingsCard user={user} onProfileUpdated={onProfileUpdated} />
+        <ChangePasswordForm title="Update your password" onSubmit={onPasswordChange} />
+      </div>
+    </div>
+  </div>
+);
+
+export default AdminSettingsOverlay;

--- a/frontend/src/components/dialog/DialogContext.jsx
+++ b/frontend/src/components/dialog/DialogContext.jsx
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+export const DialogContext = createContext(null);
+
+export const useDialogContext = () => {
+  const context = useContext(DialogContext);
+  if (!context) {
+    throw new Error('useDialog must be used within a DialogProvider');
+  }
+  return context;
+};

--- a/frontend/src/components/dialog/DialogProvider.jsx
+++ b/frontend/src/components/dialog/DialogProvider.jsx
@@ -1,0 +1,194 @@
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { DialogContext } from './DialogContext.jsx';
+
+const defaultLabels = {
+  confirmLabel: 'Confirm',
+  cancelLabel: 'Cancel',
+  acknowledgeLabel: 'OK',
+};
+
+const DialogOverlay = ({
+  dialog,
+  inputValue,
+  onInputChange,
+  onConfirm,
+  onCancel,
+}) => {
+  const {
+    title,
+    message,
+    variant,
+    confirmLabel,
+    cancelLabel,
+    acknowledgeLabel,
+    placeholder,
+    description,
+    destructive,
+  } = dialog;
+
+  const renderActions = () => {
+    if (variant === 'alert') {
+      return (
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="inline-flex min-w-[120px] items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          {acknowledgeLabel || defaultLabels.acknowledgeLabel}
+        </button>
+      );
+    }
+
+    return (
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex min-w-[120px] items-center justify-center rounded-full border border-white/40 bg-white/30 px-5 py-2.5 text-sm font-semibold text-slate-600 shadow-[0_18px_45px_-28px_rgba(15,23,42,0.3)] transition hover:bg-white/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-300"
+        >
+          {cancelLabel || defaultLabels.cancelLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className={`inline-flex min-w-[120px] items-center justify-center rounded-full px-5 py-2.5 text-sm font-semibold text-white shadow-[0_20px_45px_-24px_rgba(79,70,229,0.85)] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+            destructive
+              ? 'bg-gradient-to-r from-rose-500 via-rose-500 to-orange-500 hover:shadow-[0_25px_55px_-20px_rgba(244,63,94,0.6)]'
+              : 'bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 hover:shadow-[0_25px_55px_-20px_rgba(79,70,229,0.9)]'
+          }`}
+        >
+          {confirmLabel || defaultLabels.confirmLabel}
+        </button>
+      </div>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-[1200] flex items-center justify-center bg-slate-900/70 backdrop-blur">
+      <div className="relative w-full max-w-lg rounded-3xl border border-white/20 bg-white/60 p-6 text-slate-900 shadow-[0_30px_70px_-30px_rgba(15,23,42,0.55)]">
+        <div className="pointer-events-none absolute inset-0 rounded-3xl border border-white/40" aria-hidden="true" />
+        <div className="relative space-y-4">
+          {title ? <h2 className="text-xl font-bold text-slate-900">{title}</h2> : null}
+          {description ? (
+            <p className="text-sm font-medium text-slate-600">{description}</p>
+          ) : null}
+          {message ? (
+            <p className="whitespace-pre-line text-sm font-medium text-slate-700">{message}</p>
+          ) : null}
+          {variant === 'prompt' ? (
+            <input
+              type={dialog.inputType || 'text'}
+              value={inputValue}
+              onChange={(event) => onInputChange(event.target.value)}
+              placeholder={placeholder}
+              className="w-full rounded-2xl border border-white/45 bg-white/55 px-4 py-2.5 text-sm font-medium text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/60"
+              autoFocus
+            />
+          ) : null}
+          <div className="flex items-center justify-end gap-3 pt-2">{renderActions()}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const DialogProvider = ({ children }) => {
+  const [dialog, setDialog] = useState(null);
+  const [inputValue, setInputValue] = useState('');
+  const resolverRef = useRef(null);
+
+  const closeDialog = useCallback(
+    (result) => {
+      const resolver = resolverRef.current;
+      resolverRef.current = null;
+      setDialog(null);
+      setInputValue('');
+      if (resolver) {
+        resolver(result);
+      }
+    },
+    []
+  );
+
+  const openDialog = useCallback((nextDialog) => {
+    if (!nextDialog) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      resolverRef.current = resolve;
+      setInputValue(nextDialog.defaultValue || '');
+      setDialog(nextDialog);
+    });
+  }, []);
+
+  const confirm = useCallback(
+    (options = {}) =>
+      openDialog({ variant: 'confirm', destructive: Boolean(options.destructive), ...options }).then(
+        (result) => Boolean(result && result.confirmed)
+      ),
+    [openDialog]
+  );
+
+  const alert = useCallback(
+    (options = {}) =>
+      openDialog({ variant: 'alert', ...options }).then((result) => Boolean(result && result.confirmed)),
+    [openDialog]
+  );
+
+  const prompt = useCallback(
+    (options = {}) =>
+      openDialog({ variant: 'prompt', ...options }).then((result) => {
+        if (!result || !result.confirmed) {
+          return null;
+        }
+        return 'value' in result ? result.value : inputValue;
+      }),
+    [openDialog, inputValue]
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (!dialog) {
+      return;
+    }
+    if (dialog.variant === 'prompt') {
+      closeDialog({ confirmed: true, value: inputValue });
+      return;
+    }
+    closeDialog({ confirmed: true });
+  }, [closeDialog, dialog, inputValue]);
+
+  const handleCancel = useCallback(() => {
+    closeDialog({ confirmed: false });
+  }, [closeDialog]);
+
+  const contextValue = useMemo(
+    () => ({
+      confirm,
+      alert,
+      prompt,
+    }),
+    [alert, confirm, prompt]
+  );
+
+  return (
+    <DialogContext.Provider value={contextValue}>
+      {children}
+      {dialog ? (
+        <DialogOverlay
+          dialog={dialog}
+          inputValue={inputValue}
+          onInputChange={setInputValue}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      ) : null}
+    </DialogContext.Provider>
+  );
+};
+
+export default DialogProvider;

--- a/frontend/src/components/dialog/useDialog.js
+++ b/frontend/src/components/dialog/useDialog.js
@@ -1,0 +1,5 @@
+import { useDialogContext } from './DialogContext.jsx';
+
+const useDialog = () => useDialogContext();
+
+export default useDialog;

--- a/frontend/src/components/layout/AppShell.jsx
+++ b/frontend/src/components/layout/AppShell.jsx
@@ -1,0 +1,94 @@
+import StorageIndicator from '../StorageIndicator.jsx';
+
+const Orb = ({ style }) => (
+  <div className="orb-glow" style={style} />
+);
+
+const AppShell = ({ align = 'stretch', user, onLogout, children }) => {
+  const mainClass = align === 'center' ? 'app-main app-main--center' : 'app-main';
+
+  return (
+    <div className="app-shell">
+      <div className="app-shell__layer">
+        <Orb
+          style={{
+            top: '-22%',
+            left: '-10%',
+            width: '540px',
+            height: '540px',
+            background: 'radial-gradient(circle, rgba(59,130,246,0.3), transparent 65%)',
+          }}
+        />
+        <Orb
+          style={{
+            bottom: '-28%',
+            right: '-14%',
+            width: '620px',
+            height: '620px',
+            background: 'radial-gradient(circle, rgba(236,72,153,0.24), transparent 68%)',
+          }}
+        />
+        <Orb
+          style={{
+            top: '30%',
+            right: '12%',
+            width: '320px',
+            height: '320px',
+            background: 'radial-gradient(circle, rgba(56,189,248,0.3), transparent 62%)',
+          }}
+        />
+      </div>
+      <div className="app-shell__inner">
+        <header className="app-topbar glass-panel backdrop-sheen">
+          <div className="app-brand">
+            <span className="app-brand__mark">HTS</span>
+            <div>
+              <span className="app-brand__title">Network Access Storage</span>
+              <span className="app-brand__subtitle">Fluid workspace</span>
+            </div>
+          </div>
+          {user ? (
+            <div className="app-topbar__meta">
+              <StorageIndicator />
+              <div className="app-topbar__user">
+                <span>{user.username}</span>
+                <span className="app-topbar__chip">{user.role}</span>
+              </div>
+              <button type="button" className="app-topbar__logout" onClick={onLogout}>
+                Sign out
+              </button>
+            </div>
+          ) : (
+            <span className="glass-chip">Secure access</span>
+          )}
+        </header>
+        <main className={mainClass}>
+          <div className="app-main__background">
+            <div className="chroma-grid" />
+            <Orb
+              style={{
+                top: '-18%',
+                left: '12%',
+                width: '320px',
+                height: '320px',
+                background: 'radial-gradient(circle, rgba(59,130,246,0.35), transparent 62%)',
+              }}
+            />
+            <Orb
+              style={{
+                bottom: '-24%',
+                right: '-10%',
+                width: '420px',
+                height: '420px',
+                background: 'radial-gradient(circle, rgba(99,102,241,0.28), transparent 65%)',
+              }}
+            />
+          </div>
+          <div className="app-main__content">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -502,6 +502,13 @@ export function getCurrentUser() {
   return request('/auth/me');
 }
 
+export function updateMyProfile(body) {
+  return request('/users/me/profile', {
+    method: 'PUT',
+    body,
+  });
+}
+
 export function changeMyPassword(currentPassword, newPassword) {
   return request('/users/me/password', {
     method: 'PUT',


### PR DESCRIPTION
## Summary
- introduce a shared dialog provider and app shell layout to replace native prompts across the file manager and user manager
- redesign the admin dashboard with a hero header, modular control panel, and a workspace settings overlay that includes account management
- refresh the notice board styling and add backend support for updating usernames while mirroring the UX refinements in the Next.js frontend

## Testing
- npm run build (frontend)
- npm run build (frontend-next) *(fails: lint warnings from existing hooks and Next.js lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68ddeaaf6b84832d99a51ed6339c67aa