### PR TITLE
Add folder picker to access management and relax file locking permissions

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2027,7 +2027,7 @@ app.post('/api/items/move', requireAuth, async (req, res, next) => {
   }
 });
 
-app.post('/api/items/lock', requireAuth, requireAdmin, async (req, res, next) => {
+app.post('/api/items/lock', requireAuth, async (req, res, next) => {
   try {
     const { path: targetPath, password } = req.body;
     if (!targetPath || typeof targetPath !== 'string') {
@@ -2079,7 +2079,7 @@ app.post('/api/items/lock', requireAuth, requireAdmin, async (req, res, next) =>
   }
 });
 
-app.post('/api/items/unlock', requireAuth, requireAdmin, async (req, res, next) => {
+app.post('/api/items/unlock', requireAuth, async (req, res, next) => {
   try {
     const { path: targetPath, password } = req.body;
     if (!targetPath || typeof targetPath !== 'string') {

--- a/frontend/src/components/AccessList.jsx
+++ b/frontend/src/components/AccessList.jsx
@@ -1,4 +1,6 @@
-const AccessList = ({ access = [], selectedPath, onSelect }) => {
+const AccessList = ({ access = [], selectedPath, onSelect, viewerRole }) => {
+  const isAdmin = String(viewerRole || '').toLowerCase() === 'admin';
+
   if (!Array.isArray(access) || access.length === 0) {
     return (
       <div className="glass-panel relative flex flex-col gap-4 overflow-hidden p-5">
@@ -36,7 +38,7 @@ const AccessList = ({ access = [], selectedPath, onSelect }) => {
                   {entry.path || 'Full storage access'}
                 </span>
                 <span className={`font-mono text-xs ${isActive ? 'text-blue-700/90' : 'text-slate-500/90'}`}>
-                  Password: {entry.password}
+                  Password: {isAdmin ? entry.password : '••••••'}
                 </span>
               </button>
             </li>

--- a/frontend/src/components/DepartmentHeadDashboard.jsx
+++ b/frontend/src/components/DepartmentHeadDashboard.jsx
@@ -90,7 +90,12 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
+            <AccessList
+              access={accessList}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+              viewerRole={user.role}
+            />
           </section>
 
           {hasAssignedAccess && (
@@ -100,7 +105,7 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
                 subtitle="Work across folders assigned to your department."
                 initialPath={selectedPath}
                 rootPath={selectedPath}
-                allowLockToggle={false}
+                allowLockToggle
                 passwordLookup={passwordLookup}
               />
             </section>

--- a/frontend/src/components/FinanceDashboard.jsx
+++ b/frontend/src/components/FinanceDashboard.jsx
@@ -90,7 +90,12 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
+            <AccessList
+              access={accessList}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+              viewerRole={user.role}
+            />
           </section>
 
           {hasAssignedAccess && (
@@ -100,7 +105,7 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
                 subtitle="Work within the folders assigned to your finance role."
                 initialPath={selectedPath}
                 rootPath={selectedPath}
-                allowLockToggle={false}
+                allowLockToggle
                 passwordLookup={passwordLookup}
               />
             </section>

--- a/frontend/src/components/FolderPickerDialog.jsx
+++ b/frontend/src/components/FolderPickerDialog.jsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react';
+import { listItems } from '../services/api.js';
+
+const sanitizePath = (input) => {
+  if (typeof input !== 'string') {
+    return '';
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed
+    .replace(/\\/g, '/')
+    .replace(/\/+/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+};
+
+const FolderPickerDialog = ({
+  initialPath = '',
+  onSelect,
+  onCancel,
+}) => {
+  const startingPath = useMemo(() => sanitizePath(initialPath), [initialPath]);
+  const [currentPath, setCurrentPath] = useState(startingPath);
+  const [resolvedPath, setResolvedPath] = useState(startingPath);
+  const [breadcrumbs, setBreadcrumbs] = useState([]);
+  const [folders, setFolders] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError('');
+
+    listItems(currentPath)
+      .then((data) => {
+        if (!active) {
+          return;
+        }
+        const normalizedPath = sanitizePath(data.path || '');
+        setResolvedPath(normalizedPath);
+        setBreadcrumbs(Array.isArray(data.breadcrumbs) ? data.breadcrumbs : []);
+        const directoryItems = Array.isArray(data.items)
+          ? data.items.filter((item) => item?.type === 'directory')
+          : [];
+        setFolders(directoryItems);
+        if (normalizedPath !== currentPath) {
+          setCurrentPath(normalizedPath);
+        }
+      })
+      .catch((err) => {
+        if (!active) {
+          return;
+        }
+        setError(err.message || 'Unable to load folders');
+        setFolders([]);
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [currentPath]);
+
+  const handleNavigate = (path) => {
+    const normalized = sanitizePath(path || '');
+    setCurrentPath(normalized);
+  };
+
+  const handleSelect = (path) => {
+    const normalized = sanitizePath(path || '');
+    onSelect?.(normalized);
+  };
+
+  const handleSelectCurrent = () => {
+    handleSelect(resolvedPath);
+  };
+
+  const handleSelectRoot = () => {
+    handleSelect('');
+  };
+
+  return (
+    <div className="fixed inset-0 z-[1300] flex items-center justify-center bg-slate-900/70 backdrop-blur">
+      <div className="relative w-full max-w-3xl rounded-3xl border border-white/20 bg-white/65 p-6 text-slate-900 shadow-[0_35px_70px_-30px_rgba(15,23,42,0.6)]">
+        <div className="pointer-events-none absolute inset-0 rounded-3xl border border-white/35" aria-hidden="true" />
+        <div className="relative flex flex-col gap-5">
+          <header className="flex items-start justify-between gap-4">
+            <div className="space-y-1">
+              <h2 className="text-xl font-bold text-slate-900">Select folder</h2>
+              <p className="text-sm font-medium text-slate-600">
+                Browse the NAS structure and pick a folder to grant access.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onCancel}
+              className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white/40 px-4 py-2 text-sm font-semibold text-slate-600 shadow-[0_16px_40px_-28px_rgba(15,23,42,0.35)] transition hover:bg-white/55 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+            >
+              Close
+            </button>
+          </header>
+
+          <nav className="flex flex-wrap items-center gap-2 text-xs font-semibold text-blue-700">
+            <button
+              type="button"
+              onClick={() => handleNavigate('')}
+              className={`rounded-full px-3 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                !resolvedPath ? 'bg-blue-500 text-white shadow-[0_10px_30px_-18px_rgba(59,130,246,0.8)]' : 'bg-white/60 text-blue-600 hover:bg-white/80'
+              }`}
+            >
+              Root
+            </button>
+            {breadcrumbs.map((crumb, index) => {
+              const isLast = index === breadcrumbs.length - 1;
+              return (
+                <button
+                  key={crumb.path}
+                  type="button"
+                  onClick={() => handleNavigate(crumb.path)}
+                  className={`rounded-full px-3 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+                    isLast
+                      ? 'bg-blue-500 text-white shadow-[0_10px_30px_-18px_rgba(59,130,246,0.8)]'
+                      : 'bg-white/60 text-blue-600 hover:bg-white/80'
+                  }`}
+                >
+                  {crumb.name || 'Root'}
+                </button>
+              );
+            })}
+          </nav>
+
+          <div className="min-h-[200px] rounded-3xl border border-white/30 bg-white/55 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)]">
+            {error ? (
+              <div className="flex h-full items-center justify-center text-sm font-semibold text-rose-600">
+                {error}
+              </div>
+            ) : null}
+            {!error && loading ? (
+              <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-600">
+                Loading folders…
+              </div>
+            ) : null}
+            {!error && !loading && folders.length === 0 ? (
+              <div className="flex h-full items-center justify-center text-sm font-semibold text-slate-600">
+                No subfolders found in this location.
+              </div>
+            ) : null}
+            {!error && !loading && folders.length > 0 ? (
+              <ul className="flex flex-col gap-2">
+                {folders.map((folder) => (
+                  <li key={folder.path || folder.name}>
+                    <button
+                      type="button"
+                      onClick={() => handleNavigate(folder.path || `${resolvedPath ? `${resolvedPath}/` : ''}${folder.name}`)}
+                      className="group flex w-full items-center justify-between rounded-2xl border border-white/40 bg-white/55 px-4 py-3 text-left text-sm font-semibold text-slate-700 transition hover:border-blue-300/60 hover:bg-blue-50/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    >
+                      <span className="flex items-center gap-2">
+                        <span className="text-lg" aria-hidden="true">
+                          📁
+                        </span>
+                        <span>{folder.name}</span>
+                      </span>
+                      <span className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600 opacity-0 transition group-hover:opacity-100">
+                        Open
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="text-xs font-semibold text-slate-500">
+              Selected path:{' '}
+              <span className="font-mono text-sm text-slate-700">
+                {resolvedPath || 'Root'}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={handleSelectRoot}
+                className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white/40 px-4 py-2 text-sm font-semibold text-slate-600 shadow-[0_16px_40px_-28px_rgba(15,23,42,0.35)] transition hover:bg-white/55 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              >
+                Give full storage access
+              </button>
+              <button
+                type="button"
+                onClick={handleSelectCurrent}
+                className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 px-5 py-2.5 text-sm font-semibold text-white shadow-[0_25px_55px_-24px_rgba(79,70,229,0.9)] transition hover:shadow-[0_28px_60px_-22px_rgba(79,70,229,0.95)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+              >
+                Use this folder
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FolderPickerDialog;

--- a/frontend/src/components/ProcurementDashboard.jsx
+++ b/frontend/src/components/ProcurementDashboard.jsx
@@ -90,7 +90,12 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
+            <AccessList
+              access={accessList}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+              viewerRole={user.role}
+            />
           </section>
 
           {hasAssignedAccess && (
@@ -100,7 +105,7 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
                 subtitle="Manage shared documents for procurement operations."
                 initialPath={selectedPath}
                 rootPath={selectedPath}
-                allowLockToggle={false}
+                allowLockToggle
                 passwordLookup={passwordLookup}
               />
             </section>

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -92,7 +92,12 @@ const UserDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
+            <AccessList
+              access={accessList}
+              selectedPath={selectedPath}
+              onSelect={setSelectedPath}
+              viewerRole={user.role}
+            />
           </section>
 
           {hasAssignedAccess && (
@@ -102,7 +107,7 @@ const UserDashboard = ({ user, onPasswordChange }) => {
                 subtitle="All changes you make stay within your assigned folders."
                 initialPath={selectedPath}
                 rootPath={selectedPath}
-                allowLockToggle={false}
+                allowLockToggle
                 passwordLookup={passwordLookup}
               />
             </section>

--- a/frontend/src/components/UserManagementPanel.jsx
+++ b/frontend/src/components/UserManagementPanel.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import useDialog from './dialog/useDialog.js';
 import { fetchUsers, createUser, updateUser, deleteUser } from '../services/api.js';
+import FolderPickerDialog from './FolderPickerDialog.jsx';
 
 const normalizePath = (input) => {
   if (typeof input !== 'string') {
@@ -43,6 +44,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
   const [newUser, setNewUser] = useState(initialNewUser);
   const [savingAccess, setSavingAccess] = useState(false);
   const [updatingUser, setUpdatingUser] = useState(false);
+  const [folderPickerIndex, setFolderPickerIndex] = useState(null);
 
   const loadUsers = async () => {
     setLoading(true);
@@ -102,6 +104,24 @@ const UserManagementPanel = ({ onUsersChanged }) => {
 
   const handleAddAccess = () => {
     setAccessDraft((entries) => [...entries, { path: '', password: '' }]);
+  };
+
+  const handleOpenFolderPicker = (index) => {
+    setFolderPickerIndex(index);
+  };
+
+  const handleFolderSelected = (path) => {
+    if (folderPickerIndex === null) {
+      return;
+    }
+    setAccessDraft((entries) =>
+      entries.map((entry, idx) => (idx === folderPickerIndex ? { ...entry, path } : entry))
+    );
+    setFolderPickerIndex(null);
+  };
+
+  const handleFolderPickerClose = () => {
+    setFolderPickerIndex(null);
   };
 
   const handleSaveAccess = async () => {
@@ -355,13 +375,36 @@ const UserManagementPanel = ({ onUsersChanged }) => {
                         className="flex flex-col gap-2 rounded-2xl border border-white/30 bg-white/35 p-3 shadow-[0_18px_45px_-32px_rgba(15,23,42,0.4)] sm:flex-row sm:items-center"
                         key={`${entry.path}-${index}`}
                       >
-                        <input
-                          type="text"
-                          value={entry.path}
-                          onChange={(event) => handleAccessChange(index, 'path', event.target.value)}
-                          placeholder="Folder path (e.g. Projects/TeamA)"
-                          className="w-full rounded-2xl border border-white/35 bg-white/40 px-4 py-2.5 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/40"
-                        />
+                        <div className="flex w-full flex-col gap-1">
+                          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">
+                            Folder
+                          </span>
+                          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                            <div className="flex-1 rounded-2xl border border-white/35 bg-white/40 px-4 py-2.5 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)]">
+                              {entry.path ? entry.path : 'Full storage access'}
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <button
+                                type="button"
+                                className="inline-flex items-center justify-center rounded-full border border-white/25 bg-white/30 px-4 py-2 text-sm font-semibold text-slate-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition hover:border-blue-300/60 hover:bg-blue-50/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                                onClick={() => handleOpenFolderPicker(index)}
+                                disabled={savingAccess}
+                              >
+                                Browse…
+                              </button>
+                              {entry.path ? (
+                                <button
+                                  type="button"
+                                  className="inline-flex items-center justify-center rounded-full border border-white/25 bg-white/30 px-3 py-2 text-xs font-semibold text-rose-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition hover:border-rose-300/60 hover:bg-rose-50/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
+                                  onClick={() => handleAccessChange(index, 'path', '')}
+                                  disabled={savingAccess}
+                                >
+                                  Clear
+                                </button>
+                              ) : null}
+                            </div>
+                          </div>
+                        </div>
                         <input
                           type="text"
                           value={entry.password}
@@ -391,6 +434,13 @@ const UserManagementPanel = ({ onUsersChanged }) => {
                     </button>
                   </div>
                 </div>
+                {folderPickerIndex !== null ? (
+                  <FolderPickerDialog
+                    initialPath={accessDraft[folderPickerIndex]?.path || ''}
+                    onSelect={handleFolderSelected}
+                    onCancel={handleFolderPickerClose}
+                  />
+                ) : null}
                 <div className="relative z-10 flex flex-wrap gap-3">
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- replace manual path entry in the admin folder access editor with a folder picker dialog
- hide folder passwords from non-admin users while leaving admin visibility intact
- allow non-admin users with access to lock/unlock files and surface the controls across dashboards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de68ab6188832d88bad343caa93436