### PR TITLE
Remove folder access passwords from admin assignments

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -555,7 +555,6 @@ async function normalizeAccessEntries(access) {
       throw error;
     }
     seen.add(relativePath);
-    const password = typeof entry.password === 'string' ? entry.password.trim() : '';
     const { absolute } = resolveAbsolute(relativePath);
     try {
       const stats = await fs.stat(absolute);
@@ -572,7 +571,7 @@ async function normalizeAccessEntries(access) {
       }
       throw err;
     }
-    normalized.push({ path: relativePath, password });
+    normalized.push({ path: relativePath });
   }
   return normalized;
 }
@@ -714,19 +713,12 @@ async function assertUnlocked(relativePath, password, account) {
   if (!entry) {
     return { locks, entry: null };
   }
-  let effectivePassword = password;
-  if (!effectivePassword && account) {
-    const accessEntry = getAccessList(account).find((item) => item.path === relativePath);
-    if (accessEntry?.password) {
-      effectivePassword = accessEntry.password;
-    }
-  }
-  if (!effectivePassword) {
+  if (!password) {
     const error = new Error('Password required for locked item');
     error.status = 423;
     throw error;
   }
-  const match = await bcrypt.compare(effectivePassword, entry.hash);
+  const match = await bcrypt.compare(password, entry.hash);
   if (!match) {
     const error = new Error('Invalid password for locked item');
     error.status = 403;

--- a/backend/src/stores/accountStore.js
+++ b/backend/src/stores/accountStore.js
@@ -116,7 +116,6 @@ function getAccessList(account) {
   }
   return account.access.map((entry) => ({
     path: normalizeRelative(entry.path || ''),
-    password: String(entry.password || ''),
   }));
 }
 

--- a/frontend-next/src/components/AccessList.jsx
+++ b/frontend-next/src/components/AccessList.jsx
@@ -16,7 +16,7 @@ const AccessList = ({ access = [], selectedPath, onSelect }) => {
       <div className="pointer-events-none chroma-grid" />
       <div className="relative z-10 space-y-1">
         <h2 className="text-lg font-bold text-slate-900">Assigned folders</h2>
-        <p className="text-sm font-medium text-slate-500">Select a folder to browse files and see the associated password.</p>
+        <p className="text-sm font-medium text-slate-500">Select a folder to browse files assigned to this account.</p>
       </div>
       <ul className="relative z-10 flex flex-col gap-3">
         {access.map((entry) => {
@@ -34,9 +34,6 @@ const AccessList = ({ access = [], selectedPath, onSelect }) => {
               >
                 <span className={`text-base font-bold ${isActive ? 'text-blue-900' : 'text-slate-900'}`}>
                   {entry.path || 'Full storage access'}
-                </span>
-                <span className={`font-mono text-xs ${isActive ? 'text-blue-700/90' : 'text-slate-500/90'}`}>
-                  Password: {entry.password}
                 </span>
               </button>
             </li>

--- a/frontend-next/src/components/DepartmentHeadDashboard.jsx
+++ b/frontend-next/src/components/DepartmentHeadDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AccessList from './AccessList.jsx';
 import FileManager from './FileManager.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
@@ -6,21 +6,6 @@ import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -101,7 +78,6 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle={false}
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend-next/src/components/FinanceDashboard.jsx
+++ b/frontend-next/src/components/FinanceDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AccessList from './AccessList.jsx';
 import FileManager from './FileManager.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
@@ -6,21 +6,6 @@ import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const FinanceDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -101,7 +78,6 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle={false}
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend-next/src/components/ProcurementDashboard.jsx
+++ b/frontend-next/src/components/ProcurementDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AccessList from './AccessList.jsx';
 import FileManager from './FileManager.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
@@ -6,21 +6,6 @@ import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const ProcurementDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -101,7 +78,6 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle={false}
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend-next/src/components/UserDashboard.jsx
+++ b/frontend-next/src/components/UserDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import FileManager from './FileManager.jsx';
 import AccessList from './AccessList.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
@@ -6,21 +6,6 @@ import ProtocolHub from './ProtocolHub.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const UserDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const UserDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -103,7 +80,6 @@ const UserDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle={false}
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend-next/src/components/UserManagementPanel.jsx
+++ b/frontend-next/src/components/UserManagementPanel.jsx
@@ -59,7 +59,9 @@ const UserManagementPanel = ({ onUsersChanged }) => {
       const existing = sorted.find((user) => user.username === selectedUsername);
       const activeUser = existing || sorted[0];
       setSelectedUsername(activeUser.username);
-      setAccessDraft(activeUser.access ? activeUser.access.map((entry) => ({ ...entry })) : []);
+      setAccessDraft(
+        activeUser.access ? activeUser.access.map((entry) => ({ path: entry.path || '' })) : []
+      );
     } catch (err) {
       setError(err.message || 'Unable to load users.');
       setUsers([]);
@@ -87,7 +89,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
   const handleSelectUser = (username) => {
     setSelectedUsername(username);
     const target = users.find((user) => user.username === username);
-    setAccessDraft(target?.access ? target.access.map((entry) => ({ ...entry })) : []);
+    setAccessDraft(target?.access ? target.access.map((entry) => ({ path: entry.path || '' })) : []);
   };
 
   const handleAccessChange = (index, field, value) => {
@@ -101,7 +103,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
   };
 
   const handleAddAccess = () => {
-    setAccessDraft((entries) => [...entries, { path: '', password: '' }]);
+    setAccessDraft((entries) => [...entries, { path: '' }]);
   };
 
   const handleSaveAccess = async () => {
@@ -112,12 +114,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
     setMessage('');
     const formatted = accessDraft.map((entry) => ({
       path: normalizePath(entry.path || ''),
-      password: (entry.password || '').trim(),
     }));
-    if (formatted.some((entry) => !entry.password)) {
-      setError('Every folder access must include a password.');
-      return;
-    }
     setSavingAccess(true);
     try {
       await updateUser(selectedUser.username, { access: formatted });
@@ -360,13 +357,6 @@ const UserManagementPanel = ({ onUsersChanged }) => {
                           value={entry.path}
                           onChange={(event) => handleAccessChange(index, 'path', event.target.value)}
                           placeholder="Folder path (e.g. Projects/TeamA)"
-                          className="w-full rounded-2xl border border-white/35 bg-white/40 px-4 py-2.5 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/40"
-                        />
-                        <input
-                          type="text"
-                          value={entry.password}
-                          onChange={(event) => handleAccessChange(index, 'password', event.target.value)}
-                          placeholder="Password"
                           className="w-full rounded-2xl border border-white/35 bg-white/40 px-4 py-2.5 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/40"
                         />
                         <button

--- a/frontend/src/components/AccessList.jsx
+++ b/frontend/src/components/AccessList.jsx
@@ -1,5 +1,4 @@
-const AccessList = ({ access = [], selectedPath, onSelect, viewerRole }) => {
-  const isAdmin = String(viewerRole || '').toLowerCase() === 'admin';
+const AccessList = ({ access = [], selectedPath, onSelect }) => {
 
   if (!Array.isArray(access) || access.length === 0) {
     return (
@@ -18,17 +17,11 @@ const AccessList = ({ access = [], selectedPath, onSelect, viewerRole }) => {
       <div className="pointer-events-none chroma-grid" />
       <div className="relative z-10 space-y-1">
         <h2 className="text-lg font-bold text-slate-900">Assigned folders</h2>
-        <p className="text-sm font-medium text-slate-500">Select a folder to browse files and review any optional password.</p>
+        <p className="text-sm font-medium text-slate-500">Select a folder to browse files assigned to this account.</p>
       </div>
       <ul className="relative z-10 flex flex-col gap-3">
         {access.map((entry) => {
           const isActive = selectedPath === entry.path;
-          const hasPassword = Boolean(entry.password);
-          const passwordLabel = hasPassword
-            ? isAdmin
-              ? entry.password
-              : '••••••'
-            : 'No password required';
           return (
             <li key={entry.path || '(root)'}>
               <button
@@ -42,9 +35,6 @@ const AccessList = ({ access = [], selectedPath, onSelect, viewerRole }) => {
               >
                 <span className={`text-base font-bold ${isActive ? 'text-blue-900' : 'text-slate-900'}`}>
                   {entry.path || 'Full storage access'}
-                </span>
-                <span className={`font-mono text-xs ${isActive ? 'text-blue-700/90' : 'text-slate-500/90'}`}>
-                  Password: {passwordLabel}
                 </span>
               </button>
             </li>

--- a/frontend/src/components/DepartmentHeadDashboard.jsx
+++ b/frontend/src/components/DepartmentHeadDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AccessList from './AccessList.jsx';
 import FileManager from './FileManager.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
@@ -6,21 +6,6 @@ import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -94,7 +71,6 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
               access={accessList}
               selectedPath={selectedPath}
               onSelect={setSelectedPath}
-              viewerRole={user.role}
             />
           </section>
 
@@ -106,7 +82,6 @@ const DepartmentHeadDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend/src/components/FinanceDashboard.jsx
+++ b/frontend/src/components/FinanceDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AccessList from './AccessList.jsx';
 import FileManager from './FileManager.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
@@ -6,21 +6,6 @@ import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const FinanceDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -90,12 +67,7 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList
-              access={accessList}
-              selectedPath={selectedPath}
-              onSelect={setSelectedPath}
-              viewerRole={user.role}
-            />
+            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
           </section>
 
           {hasAssignedAccess && (
@@ -106,7 +78,6 @@ const FinanceDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend/src/components/ProcurementDashboard.jsx
+++ b/frontend/src/components/ProcurementDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import AccessList from './AccessList.jsx';
 import FileManager from './FileManager.jsx';
 import ProtocolHub from './ProtocolHub.jsx';
@@ -6,21 +6,6 @@ import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const ProcurementDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -90,12 +67,7 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList
-              access={accessList}
-              selectedPath={selectedPath}
-              onSelect={setSelectedPath}
-              viewerRole={user.role}
-            />
+            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
           </section>
 
           {hasAssignedAccess && (
@@ -106,7 +78,6 @@ const ProcurementDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend/src/components/UserDashboard.jsx
+++ b/frontend/src/components/UserDashboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import FileManager from './FileManager.jsx';
 import AccessList from './AccessList.jsx';
 import ChangePasswordForm from './ChangePasswordForm.jsx';
@@ -6,21 +6,6 @@ import ProtocolHub from './ProtocolHub.jsx';
 import NoticeBoard from './NoticeBoard.jsx';
 import ProcurementWorkspace from './ProcurementWorkspace.jsx';
 import ProcurementWindow from './ProcurementWindow.jsx';
-
-const normalizePath = (input) => {
-  if (typeof input !== 'string') {
-    return '';
-  }
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return '';
-  }
-  return trimmed
-    .replace(/\\/g, '/')
-    .replace(/\/+/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
-};
 
 const UserDashboard = ({ user, onPasswordChange }) => {
   const accessList = Array.isArray(user.access) ? user.access : [];
@@ -31,14 +16,6 @@ const UserDashboard = ({ user, onPasswordChange }) => {
   useEffect(() => {
     setSelectedPath(accessList[0]?.path || '');
   }, [user.username, accessList]);
-
-  const passwordLookup = useMemo(() => {
-    return (path) => {
-      const normalized = normalizePath(path);
-      const match = accessList.find((entry) => normalizePath(entry.path || '') === normalized);
-      return match?.password;
-    };
-  }, [accessList]);
 
   const hasAssignedAccess = accessList.length > 0;
 
@@ -92,12 +69,7 @@ const UserDashboard = ({ user, onPasswordChange }) => {
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-6">
           <section>
-            <AccessList
-              access={accessList}
-              selectedPath={selectedPath}
-              onSelect={setSelectedPath}
-              viewerRole={user.role}
-            />
+            <AccessList access={accessList} selectedPath={selectedPath} onSelect={setSelectedPath} />
           </section>
 
           {hasAssignedAccess && (
@@ -108,7 +80,6 @@ const UserDashboard = ({ user, onPasswordChange }) => {
                 initialPath={selectedPath}
                 rootPath={selectedPath}
                 allowLockToggle
-                passwordLookup={passwordLookup}
               />
             </section>
           )}

--- a/frontend/src/components/UserManagementPanel.jsx
+++ b/frontend/src/components/UserManagementPanel.jsx
@@ -61,7 +61,9 @@ const UserManagementPanel = ({ onUsersChanged }) => {
       const existing = sorted.find((user) => user.username === selectedUsername);
       const activeUser = existing || sorted[0];
       setSelectedUsername(activeUser.username);
-      setAccessDraft(activeUser.access ? activeUser.access.map((entry) => ({ ...entry })) : []);
+      setAccessDraft(
+        activeUser.access ? activeUser.access.map((entry) => ({ path: entry.path || '' })) : []
+      );
     } catch (err) {
       setError(err.message || 'Unable to load users.');
       setUsers([]);
@@ -89,7 +91,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
   const handleSelectUser = (username) => {
     setSelectedUsername(username);
     const target = users.find((user) => user.username === username);
-    setAccessDraft(target?.access ? target.access.map((entry) => ({ ...entry })) : []);
+    setAccessDraft(target?.access ? target.access.map((entry) => ({ path: entry.path || '' })) : []);
   };
 
   const handleAccessChange = (index, field, value) => {
@@ -150,7 +152,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
       const existing = new Set(entries.map((entry) => normalizePath(entry.path || '')));
       const additions = deduped
         .filter((path) => !existing.has(path))
-        .map((path) => ({ path, password: '' }));
+        .map((path) => ({ path }));
       additionsCount = additions.length;
       if (additions.length === 0) {
         return entries;
@@ -165,7 +167,7 @@ const UserManagementPanel = ({ onUsersChanged }) => {
       return;
     }
     setError('');
-    setMessage(`Added ${additionsCount} folder${additionsCount > 1 ? 's' : ''}. Passwords are optional.`);
+    setMessage(`Added ${additionsCount} folder${additionsCount > 1 ? 's' : ''}.`);
   };
 
   const handleFolderPickerClose = () => {
@@ -180,7 +182,6 @@ const UserManagementPanel = ({ onUsersChanged }) => {
     setMessage('');
     const formatted = accessDraft.map((entry) => ({
       path: normalizePath(entry.path || ''),
-      password: (entry.password || '').trim(),
     }));
     setSavingAccess(true);
     try {
@@ -449,13 +450,6 @@ const UserManagementPanel = ({ onUsersChanged }) => {
                             </div>
                           </div>
                         </div>
-                        <input
-                          type="text"
-                          value={entry.password}
-                          onChange={(event) => handleAccessChange(index, 'password', event.target.value)}
-                          placeholder="Password (optional)"
-                          className="w-full rounded-2xl border border-white/35 bg-white/40 px-4 py-2.5 text-sm font-medium text-slate-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-400/40"
-                        />
                         <button
                           type="button"
                           className="inline-flex items-center justify-center rounded-full border border-white/25 bg-white/30 px-4 py-2 text-sm font-semibold text-slate-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] transition hover:border-white/35 hover:bg-white/45 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60"


### PR DESCRIPTION
## Summary
- drop password persistence from folder access normalization and locked-item checks in the backend
- update the React admin user management interface to manage folder assignments without password inputs
- mirror the same no-password access behaviour in the alternate frontend implementation

## Testing
- No automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68df415a8c4c832d8bafd7ab0029b9b3