### PR TITLE
Add recycle bin support for NAS items

### DIFF
--- a/backend/src/stores/recycleBinStore.js
+++ b/backend/src/stores/recycleBinStore.js
@@ -1,0 +1,66 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+const RECYCLE_BIN_FILE = path.join(__dirname, '..', '..', 'recycleBin.json');
+
+async function readRecycleBinFile() {
+  try {
+    const data = await fs.readFile(RECYCLE_BIN_FILE, 'utf8');
+    const parsed = JSON.parse(data);
+    if (Array.isArray(parsed)) {
+      return parsed.map((entry) => ({ ...entry }));
+    }
+    if (parsed && Array.isArray(parsed.entries)) {
+      return parsed.entries.map((entry) => ({ ...entry }));
+    }
+    return [];
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      await fs.writeFile(
+        RECYCLE_BIN_FILE,
+        JSON.stringify({ entries: [] }, null, 2)
+      );
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function writeRecycleBinFile(entries) {
+  const payload = Array.isArray(entries) ? entries.map((entry) => ({ ...entry })) : [];
+  await fs.writeFile(
+    RECYCLE_BIN_FILE,
+    JSON.stringify({ entries: payload }, null, 2)
+  );
+}
+
+async function ensureRecycleBinInitialized() {
+  await readRecycleBinFile();
+}
+
+async function loadRecycleBinEntries() {
+  const entries = await readRecycleBinFile();
+  return entries.map((entry) => ({ ...entry }));
+}
+
+async function saveRecycleBinEntries(entries) {
+  await writeRecycleBinFile(entries);
+}
+
+async function addRecycleBinEntry(entry) {
+  if (!entry || typeof entry !== 'object') {
+    throw new Error('Recycle bin entry must be an object');
+  }
+  const entries = await readRecycleBinFile();
+  entries.push({ ...entry });
+  await writeRecycleBinFile(entries);
+  return entry;
+}
+
+module.exports = {
+  ensureRecycleBinInitialized,
+  loadRecycleBinEntries,
+  saveRecycleBinEntries,
+  addRecycleBinEntry,
+};
+

--- a/frontend/src/components/RecycleBin.jsx
+++ b/frontend/src/components/RecycleBin.jsx
@@ -1,0 +1,132 @@
+import { RotateCcw, Trash2, RefreshCw } from 'lucide-react';
+import formatBytes from '../utils/formatBytes.js';
+
+const formatTimestamp = (value) => {
+  if (!value) {
+    return 'Unknown time';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return 'Unknown time';
+  }
+  return date.toLocaleString();
+};
+
+const formatLocation = (entry) => {
+  if (entry?.originalParent) {
+    return `/${entry.originalParent}`;
+  }
+  if (entry?.originalPath) {
+    return `/${entry.originalPath}`;
+  }
+  return 'Home';
+};
+
+const formatType = (type) => (type === 'directory' ? 'Folder' : 'File');
+
+const RecycleBin = ({
+  items = [],
+  loading = false,
+  errorMessage = '',
+  onRefresh,
+  onRestore,
+  onDelete,
+}) => {
+  const hasItems = Array.isArray(items) && items.length > 0;
+
+  return (
+    <div className="rounded-2xl border border-white/25 bg-white/30 p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] backdrop-blur-xl">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold text-slate-900">Deleted items</h2>
+          <p className="text-xs font-medium text-slate-600">
+            Only items you deleted appear here. Admins can see all deleted files.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-xl border border-blue-400/40 bg-blue-100/60 px-3 py-2 text-sm font-semibold text-blue-900 shadow-inner transition hover:bg-blue-200/80 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {errorMessage ? (
+        <div className="mb-4 rounded-xl border border-rose-200/70 bg-rose-100/80 px-4 py-3 text-sm font-semibold text-rose-600 shadow-[0_12px_30px_-18px_rgba(244,63,94,0.45)]" role="alert">
+          {errorMessage}
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="flex min-h-[180px] items-center justify-center rounded-xl border border-white/25 bg-white/40 text-sm font-semibold text-blue-600 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+          Loading recycle bin…
+        </div>
+      ) : hasItems ? (
+        <div className="space-y-3">
+          {items.map((item) => {
+            const sizeLabel = item.type === 'directory' || item.size == null ? '—' : formatBytes(item.size);
+            const deletedLabel = formatTimestamp(item.deletedAt);
+            const locationLabel = formatLocation(item);
+            return (
+              <div
+                key={item.id}
+                className="rounded-xl border border-white/20 bg-white/45 p-4 shadow-[0_10px_30px_rgba(15,23,42,0.08)] backdrop-blur-xl"
+              >
+                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                  <div className="space-y-1">
+                    <div className="text-sm font-semibold text-slate-900">{item.name}</div>
+                    <div className="text-xs font-medium uppercase tracking-[0.25em] text-blue-500">
+                      {formatType(item.type)}
+                    </div>
+                    <div className="text-xs text-slate-600">
+                      Deleted {deletedLabel}
+                    </div>
+                    <div className="text-xs text-slate-600">
+                      Original location: {locationLabel}
+                    </div>
+                    {item.owner ? (
+                      <div className="text-xs text-slate-600">Deleted by: {item.owner}</div>
+                    ) : null}
+                  </div>
+                  <div className="flex flex-col items-start gap-3 md:items-end">
+                    <span className="rounded-full border border-white/40 bg-white/40 px-3 py-1 text-xs font-semibold text-slate-700 shadow-inner">
+                      Size: {sizeLabel}
+                    </span>
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => onRestore?.(item)}
+                        className="inline-flex items-center gap-1 rounded-xl border border-emerald-300/70 bg-emerald-100/70 px-3 py-2 text-sm font-semibold text-emerald-700 shadow-inner transition hover:bg-emerald-200/80"
+                      >
+                        <RotateCcw size={16} />
+                        Restore
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDelete?.(item)}
+                        className="inline-flex items-center gap-1 rounded-xl border border-rose-300/70 bg-rose-100/70 px-3 py-2 text-sm font-semibold text-rose-700 shadow-inner transition hover:bg-rose-200/80"
+                      >
+                        <Trash2 size={16} />
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-white/20 bg-white/40 px-4 py-10 text-center text-sm font-medium text-slate-600 shadow-inner">
+          No deleted items found. When you delete files, they will appear here until you restore or remove them permanently.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RecycleBin;
+

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -474,6 +474,32 @@ export function deleteItem(path, password) {
   });
 }
 
+const normalizeIdsPayload = (ids) => {
+  if (Array.isArray(ids)) {
+    return ids.map((value) => String(value || '').trim()).filter(Boolean);
+  }
+  const single = String(ids || '').trim();
+  return single ? [single] : [];
+};
+
+export function listRecycleBinItems() {
+  return request('/recycle-bin');
+}
+
+export function restoreRecycleBinItems(ids) {
+  return request('/recycle-bin/restore', {
+    method: 'POST',
+    body: { ids: normalizeIdsPayload(ids) },
+  });
+}
+
+export function purgeRecycleBinItems(ids) {
+  return request('/recycle-bin', {
+    method: 'DELETE',
+    body: { ids: normalizeIdsPayload(ids) },
+  });
+}
+
 export function renameItem(path, newName, password) {
   return request('/items/rename', {
     method: 'PUT',

--- a/frontend/src/utils/formatBytes.js
+++ b/frontend/src/utils/formatBytes.js
@@ -1,0 +1,21 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+const formatBytes = (value) => {
+  if (!Number.isFinite(value) || value < 0) {
+    return '0 B';
+  }
+  if (value === 0) {
+    return '0 B';
+  }
+  let current = value;
+  let unitIndex = 0;
+  while (current >= 1024 && unitIndex < UNITS.length - 1) {
+    current /= 1024;
+    unitIndex += 1;
+  }
+  const precision = current >= 100 ? 0 : current >= 10 ? 1 : 2;
+  return `${current.toFixed(precision)} ${UNITS[unitIndex]}`;
+};
+
+export default formatBytes;
+


### PR DESCRIPTION
## Summary
- add server-side recycle bin storage, move deletions into it, and expose list/restore/purge APIs
- persist recycle bin metadata in a dedicated store for reuse on startup
- add a recycle bin view in the file manager with restore/permanent delete controls and shared byte formatting helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8d1a96dfc832dab4ae80432510cef